### PR TITLE
Add wondelai/skills to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Please ensure your plugin:
 - [Plugin Development Guide](https://code.claude.com/docs/en/plugins)
 - [Discover Plugins](https://code.claude.com/docs/en/discover-plugins)
 - [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) - More skills and resources
+- [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX, marketing, sales, product strategy, and growth
 
 ## License
 


### PR DESCRIPTION
Adds [wondelai/skills](https://github.com/wondelai/skills) to Resources — 25 agent skills covering UX design, marketing/CRO, sales, product strategy, and business growth. Install: `npx skills add wondelai/skills`. License: MIT.