### PR TITLE
Add context-memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [context-memory](./context-memory) - Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5. Save with /remember, search with /recall.
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 
 ## Getting Started

--- a/context-memory/.claude-plugin/plugin.json
+++ b/context-memory/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "context-memory",
+  "description": "Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5",
+  "version": "1.3.1",
+  "author": {
+    "name": "ErebusEnigma",
+    "url": "https://github.com/ErebusEnigma"
+  },
+  "repository": "https://github.com/ErebusEnigma/context-memory",
+  "homepage": "https://github.com/ErebusEnigma/context-memory",
+  "keywords": [
+    "memory",
+    "context",
+    "sqlite",
+    "fts5",
+    "search",
+    "sessions",
+    "persistence"
+  ]
+}

--- a/context-memory/commands/remember.md
+++ b/context-memory/commands/remember.md
@@ -1,0 +1,38 @@
+---
+allowed-tools: Bash(python:*)
+description: "Save the current session to persistent context memory"
+argument-hint: "[note]"
+---
+
+# /remember Command
+
+Save the current session to context memory with an optional annotation.
+
+## Usage
+
+```
+/remember [note]
+```
+
+**Arguments:**
+- `note` (optional): A personal annotation or tag to help find this session later
+
+## Workflow
+
+When the user runs `/remember`:
+
+1. **Generate Session Summary** - Analyze the conversation and create a structured summary (brief, detailed, key decisions, problems solved, technologies, outcome)
+2. **Extract Topics** - Identify 3-8 relevant topics (lowercase terms)
+3. **Identify Key Code** - Extract significant code snippets with language and context
+4. **Extract Key Messages** - Select 5-15 important messages
+5. **Save via JSON stdin** - Pipe complete JSON to `db_save.py --json -`
+6. **Confirm to User** - Report summary, topics, counts
+
+## Installation
+
+Requires the full context-memory plugin:
+```bash
+git clone https://github.com/ErebusEnigma/context-memory.git
+cd context-memory
+python install.py
+```

--- a/context-memory/hooks/hooks.json
+++ b/context-memory/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/skills/context-memory/scripts/auto_save.py",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/skills/context-memory/scripts/pre_compact_save.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/context-memory/skills/context-memory/SKILL.md
+++ b/context-memory/skills/context-memory/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: "context-memory"
+description: >
+  Saves and searches past Claude Code sessions so context, decisions, and
+  code persist across conversations.
+license: "MIT"
+compatibility: "Python >= 3.8"
+allowed-tools: "Bash(python:*)"
+metadata:
+  author: "ErebusEnigma"
+  version: "1.3.1"
+---
+
+# Context Memory Skill
+
+Saves and searches past Claude Code sessions so context, decisions, and code persist across conversations.
+
+## Trigger Phrases
+
+- "remember this" / "save this session"
+- "recall" / "search past sessions"
+- "what did we discuss about..."
+- "find previous work on..."
+
+## Features
+
+- Cross-session memory with structured AI summaries
+- Full-text search with FTS5 and Porter stemming (<50ms)
+- Auto-save on exit and pre-compact checkpoints
+- Optional web dashboard and MCP server
+
+## Commands
+
+- `/remember [note]` - Save session
+- `/recall <query> [--project] [--detailed] [--limit N]` - Search sessions
+
+## Source
+
+https://github.com/ErebusEnigma/context-memory

--- a/marketplace.json
+++ b/marketplace.json
@@ -166,6 +166,13 @@
       "tags": ["security", "owasp", "vulnerabilities"]
     },
     {
+      "name": "context-memory",
+      "category": "productivity",
+      "description": "Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5",
+      "author": "ErebusEnigma",
+      "tags": ["memory", "context", "search", "sessions", "sqlite", "persistence"]
+    },
+    {
       "name": "developer-growth-analysis",
       "category": "productivity",
       "description": "Analyze coding patterns and get personalized learning resources",


### PR DESCRIPTION
## New Plugin: context-memory

**Category**: Developer Productivity
**Repository**: https://github.com/ErebusEnigma/context-memory
**License**: MIT

### What it does

Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5.

- `/remember` saves sessions with AI-generated structured summaries, topics, and code snippets
- `/recall` searches past sessions with two-tier FTS5 full-text search (<50ms)
- Auto-save hook captures context on exit; pre-compact hook preserves full conversation before compaction
- Optional web dashboard with analytics, and MCP server for programmatic access
- 364 tests, zero core dependencies, cross-platform (Windows/macOS/Linux)

### Changes

- Added `context-memory/` plugin folder with plugin.json, commands, skills, and hooks
- Added entry in README under Developer Productivity
- Added entry in marketplace.json