### PR TITLE
Add nano-banana: Google Gemini image generation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 
+### Image Generation
+
+- [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.
+
 ## Getting Started
 
 ### Using Plugins


### PR DESCRIPTION
## Plugin: Nano Banana

**Repository:** https://github.com/Ibrahim-3d/nano-banana-claude-plugin

**What it does:**
Nano Banana is a Google Gemini image generation plugin for Claude Code. It brings every Gemini image generation mode into Claude Code through a single `/genimage` slash command backed by 8 Python scripts and an autonomous AI agent.

**Capabilities:**
- Text-to-image generation
- Text-guided image editing (inpainting, add/remove objects, background swap, bring sketches to life)
- Style transfer between two images
- Multi-image composition (up to 14 references)
- 4K resolution generation (4096×4096)
- Google Search grounded image generation (real-time data)
- Multi-turn chat-based iterative editing

**Models used:**
- `gemini-2.5-flash-image` (Nano Banana) — fast, high-volume
- `gemini-3-pro-image-preview` (Nano Banana Pro) — 4K, search grounding, 14 reference images

**Install:**
```bash
/plugin marketplace add Ibrahim-3d/nano-banana-claude-plugin
/plugin install nano-banana@nano-banana
```

**Quick demo:**
After installing, run: `/genimage a photorealistic golden retriever puppy on a rainy window ledge, warm bokeh lighting`