### PR TITLE
Add Plan-Build-Run workflow orchestration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
+- [plan-build-run](./plan-build-run) - Context-engineered development workflow that solves context rot. 21 commands, 10 agents, 15 hooks, wave-based parallel execution, and kill-safe state.
 
 ## Getting Started
 

--- a/plan-build-run/README.md
+++ b/plan-build-run/README.md
@@ -1,0 +1,27 @@
+# Plan-Build-Run
+
+Context-engineered development workflow for Claude Code. Solves context rot through
+disciplined subagent delegation, structured planning, atomic execution, and
+goal-backward verification.
+
+## What it does
+
+- Keeps orchestrator at ~15% context by delegating to fresh subagent windows
+- 21 `/pbr:*` slash commands (begin, plan, build, review, debug, resume, etc.)
+- 10 specialized agents with configurable model profiles
+- 15 lifecycle hooks enforcing commit format, context budget, plan compliance
+- Wave-based parallel execution with atomic commits
+- Kill-safe: all state lives on disk in `.planning/`
+
+## Install
+
+```bash
+claude plugin marketplace add SienkLogic/plan-build-run
+claude plugin install pbr@plan-build-run
+```
+
+## Links
+
+- **Repository**: https://github.com/SienkLogic/plan-build-run
+- **Wiki**: https://github.com/SienkLogic/plan-build-run/wiki
+- **License**: MIT


### PR DESCRIPTION
## Add Plan-Build-Run

**Category**: Developer Productivity

Plan-Build-Run is a Claude Code plugin that solves context rot — quality degradation as
the context window fills during long sessions. It keeps the main orchestrator lean
(~15% context) by delegating work to fresh subagent contexts.

### Checklist
- [x] Addresses a real use case (context management during multi-phase development)
- [x] Doesn't duplicate existing functionality (no other plugin focuses on context rot)
- [x] Follows the template structure
- [x] Has been tested (780+ tests, CI on 3 OS x 3 Node versions)

**Repo**: https://github.com/SienkLogic/plan-build-run