### PR TITLE
Add Speech AI plugin to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment (phoneme-level scoring), text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

Adds **Speech AI** plugin to the **Integrations** section.

Speech AI is a Claude plugin providing:
- **Pronunciation assessment** with phoneme-level scoring (17MB model, <300ms latency)
- **Text-to-speech** synthesis
- **Speech-to-text** transcription
- 8 MCP tools for language learning, accessibility, and voice applications

This enables Claude users to add speech and pronunciation capabilities to their workflows.

## Checklist
- [x] Entry added to existing Integrations section
- [x] Description follows the existing format
- [x] Link points to a public GitHub repository