### PR TITLE
Add Manifest — cost observability plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [perf](./perf) - Performance analysis and optimization. Identify bottlenecks and improve speed.
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
+- [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
 
 ### Documentation & Security
 


### PR DESCRIPTION
## Summary
- Adds [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) to the list
- Open-source cost observability platform for OpenClaw agents
- Includes a Claude Code skill for guided plugin setup
- 3.3k GitHub stars, MIT licensed, self-hosted

## Why it belongs here
Manifest extends Claude Code with cost observability capabilities for OpenClaw agents. It includes a dedicated SKILL.md and runs as a plugin with OTLP ingestion and automatic pricing for 28+ models.