### PR TITLE
Add LightCMS to Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [LightCMS](https://github.com/jonradoff/lightcms) - AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary
- Adds [LightCMS](https://github.com/jonradoff/lightcms) to the **Integrations** section
- AI-native CMS with 41 MCP tools for managing websites through natural language (pages, templates, assets, themes, collections, redirects, content versioning)
- Placed alphabetically after `connect-apps`

## Checklist
- [x] Addresses a real use case (CMS management via Claude)
- [x] Doesn't duplicate existing functionality
- [x] Follows existing entry format
- [x] Tested — LightCMS is a live, working MCP server