### PR TITLE
Add pixelmuse to Image Generation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Image Generation
 
 - [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.
+- [pixelmuse](https://github.com/starmorph/pixelmuse-cli) - AI image generation with 6 models (Flux, Imagen 3, Recraft V4, Nano Banana). Ships as a CLI, MCP server, and Claude Code skill. Generate images from natural language with `/pixelmuse-generate`.
 
 ## Getting Started
 


### PR DESCRIPTION
Adds [pixelmuse](https://github.com/starmorph/pixelmuse-cli) to the Image Generation section.

AI image generation with 6 models (Flux, Imagen 3, Recraft V4, Nano Banana). Works as a Claude Code skill (`/pixelmuse-generate`), MCP server, and standalone CLI.

- npm: https://www.npmjs.com/package/pixelmuse
- Github http://github.com/starmorph/pixelmuse-cli/
- SKILL.md: https://github.com/starmorph/pixelmuse-cli/blob/main/SKILL.md
- Docs https://www.pixelmuse.studio/developers/cli