### PR TITLE
Add OpenPaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Open-source personal assistant wizard for Claude Code — adds 39+ skills (email, notes, smart home, focus mode, task dashboard, Telegram bot, scheduling) via interactive setup. `npx pawmode`
 
 ### Image Generation
 


### PR DESCRIPTION
Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Developer Productivity section.

OpenPaw is an open-source personal assistant wizard for Claude Code. It adds 39+ skills (email, notes, smart home, focus mode, task dashboard, Telegram bot, scheduling) via an interactive setup wizard. Install with `npx pawmode`.

- No daemon, no cloud dependency, MIT licensed
- Works as a CLI that configures Claude Code skills, hooks, and permissions
- Categories: communication, productivity, smart home, automation, developer tools