### PR TITLE
Add founder-toolkit: startup skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 
+### Business & Startup
+
+- [founder-toolkit](https://github.com/mooster/founder-toolkit) - 4 skills for startup founders: investor update writer (YC/a16z format), pitch deck reviewer (10-dimension VC scoring), SaaS metrics dashboard with stage benchmarks, and outreach lead scorer (ICP-first, tested on 300+ companies). Built by Mu Chen, CEO of Canopy Cloud.
+
 ### Image Generation
 
 - [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.


### PR DESCRIPTION
## Add founder-toolkit

**Repository:** https://github.com/mooster/founder-toolkit

4 production-quality skills for startup founders:
- **investor-update** — Generate professional investor updates (YC/a16z format, EN/中文)
- **pitch-reviewer** — Review pitch decks with 10-dimension VC scoring rubric
- **startup-metrics** — Full SaaS metrics suite with benchmark context
- **lead-scorer** — Score outreach leads with ICP methodology + email verification

Built from real operational experience running a $120B+ AUM fintech (60+ institutional clients).

**License:** MIT