### PR TITLE
Update skill-bus to latest

### DIFF
--- a/skill-bus/LICENSE
+++ b/skill-bus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joey Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skill-bus/README.md
+++ b/skill-bus/README.md
@@ -245,7 +245,7 @@ Every subscription has a `when` field that controls when it fires relative to th
 
 **Post** fires immediately after the skill's tool call returns — not after Claude has finished acting on it. This is a narrow window: the skill tool has responded, but Claude hasn't necessarily completed the work the skill kicked off. Post is useful for reminders or supplementary guidance that should appear after the skill loads but before Claude wraps up. Conditions are evaluated at post-fire time.
 
-**Complete** is different from both. It fires after Claude signals that it has finished the skill's *entire scope of work* — not just the tool call, but everything the skill asked Claude to do. This is a synthetic signal: during pre-timing, Skill Bus auto-injects an instruction telling Claude to run `/skill-bus:complete` when the work is done. Claude then fires that signal, and Skill Bus evaluates the complete-timing subscriptions at that point (including conditions). This enables skill-to-skill chaining: "after writing the plan, run the code review."
+**Complete** is different from both. It fires after Claude signals that it has finished the skill's *entire scope of work* — not just the tool call, but everything the skill asked Claude to do. This is a synthetic signal: during pre-timing, Skill Bus auto-injects an instruction telling Claude to invoke `skill-bus:complete` via the Skill tool when the work is done. Claude then fires that signal, and Skill Bus evaluates the complete-timing subscriptions at that point (including conditions). This enables skill-to-skill chaining: "after writing the plan, run the code review."
 
 Complete timing is experimental and requires two settings:
 - `"completionHooks": true` — feature flag to enable the mechanism
@@ -632,7 +632,7 @@ The `session-stats` handler generates a live telemetry summary. If it fails, the
 
 ## Testing
 
-337 tests across four suites:
+342 tests across four suites:
 
 ```bash
 # Run all tests
@@ -644,10 +644,10 @@ bash tests/test_telemetry.sh
 # Condition tests (24 tests — all 6 condition types + edge cases)
 bash tests/test_conditions.sh
 
-# CLI tests (106 tests — groups A-L: format, list, simulate, scope, skills, inserts, review, scan, set, add-insert, complete timing, hardening guards)
+# CLI tests (108 tests — groups A-L: format, list, simulate, scope, skills, inserts, review, scan, set, add-insert, complete timing, hardening guards)
 bash tests/test_cli.sh
 
-# Integration tests (155 tests — groups H-W: dispatch, monitor, conditions, merge, edge cases, nudge, dynamic, onboard, complete timing)
+# Integration tests (158 tests — groups H-W: dispatch, monitor, conditions, merge, edge cases, nudge, dynamic, onboard, complete timing)
 bash tests/test_comprehensive.sh
 ```
 
@@ -701,8 +701,8 @@ skill-bus/
 └── tests/
     ├── test_telemetry.sh       # 52 telemetry tests
     ├── test_conditions.sh      # 24 condition tests
-    ├── test_cli.sh             # 106 CLI tests
-    └── test_comprehensive.sh   # 155 integration tests
+    ├── test_cli.sh             # 108 CLI tests
+    └── test_comprehensive.sh   # 158 integration tests
 ```
 
 ### Tech Stack

--- a/skill-bus/commands/add-sub.md
+++ b/skill-bus/commands/add-sub.md
@@ -36,7 +36,7 @@ Ask using AskUserQuestion:
 **"When should this fire?"**
 - **Pre** - Before the skill loads. Use for: adding context, referencing files, setting up state.
 - **Post** - After the skill tool returns. Use for: supplementing skill output.
-- **Complete** *(experimental)* - After Claude finishes the skill's full scope of work. Use for: triggering follow-up skills, capturing outputs, chaining workflows. Auto-injects "you MUST run /skill-bus:complete" instruction. Requires `"completionHooks": true` in settings.
+- **Complete** *(experimental)* - After Claude finishes the skill's full scope of work. Use for: triggering follow-up skills, capturing outputs, chaining workflows. Auto-injects a completion trigger instruction telling Claude to invoke `skill-bus:complete` via the Skill tool when done. Requires `"completionHooks": true` in settings.
 
 ### Step 4: Insert Selection
 

--- a/skill-bus/commands/complete.md
+++ b/skill-bus/commands/complete.md
@@ -12,9 +12,9 @@ This command is a **signal**, not an interactive command. It is automatically in
 
 When skill-bus detects that a skill (e.g. `superpowers:writing-plans`) has subscriptions with `"when": "complete"`, it injects an instruction during the pre-hook:
 
-> "When you have FULLY completed the work described by this skill, you MUST run `/skill-bus:complete superpowers:writing-plans`"
+> "You MUST invoke the Skill tool with skill: `skill-bus:complete` and args: `superpowers:writing-plans`"
 
-Claude runs this command when done. The PreToolUse hook intercepts it and fires the downstream subscriptions, injecting their context ABOVE this command markdown.
+Claude invokes this command when done. The PreToolUse hook intercepts it and fires the downstream subscriptions, injecting their context ABOVE this command markdown.
 
 ## Arguments
 

--- a/skill-bus/lib/dispatcher.py
+++ b/skill-bus/lib/dispatcher.py
@@ -95,8 +95,7 @@ DEFAULT_SETTINGS = {
     "telemetry": False,
     "observeUnmatched": False,
     "telemetryPath": "",
-    "maxLogSizeKB": 512,
-    "completionHooks": False
+    "maxLogSizeKB": 512
 }
 
 # Collector for non-fatal warnings to include in systemMessage
@@ -666,7 +665,8 @@ def _main():
             completion_instruction = (
                 f"\n\n---\n[skill-bus] COMPLETION TRIGGER: When you have FULLY completed "
                 f"the work described by this skill — not begun it, FULLY delivered all "
-                f"outputs — you MUST run `/skill-bus:complete {skill_name}{depth_arg}` to trigger "
+                f"outputs — you MUST invoke the Skill tool with skill: \"skill-bus:complete\" "
+                f"and args: \"{skill_name}{depth_arg}\" to trigger "
                 f"downstream subscriptions. Do NOT skip this step."
             )
 


### PR DESCRIPTION
## Summary
- Fix completion instruction to use explicit Skill tool parameters (prevents "Unknown skill" errors)
- Correct test counts in README (342 total: 52 + 24 + 108 + 158)
- Add MIT LICENSE

Source: https://github.com/joeymnguyen/skill-bus