### PR TITLE
Add claude-recap to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [claude-recap](https://github.com/hatawong/claude-recap) - Topic-based automatic memory for Claude Code. Tracks topics within sessions, archives summaries on topic switch, and injects history into new sessions. Survives context compaction via JSONL cold-read. 100% local Markdown storage.
 
 ### Image Generation
 


### PR DESCRIPTION
## What

Adds [claude-recap](https://github.com/hatawong/claude-recap) to the Developer Productivity section.

## About claude-recap

Topic-based automatic memory plugin for Claude Code — never lose context across sessions or compactions.

- **Automatic topic archival** — Stop hook detects topic changes, archives summaries as Markdown files
- **Cross-session memory** — SessionStart hook injects topic history and user preferences
- **Compaction recovery** — Cold-reads from JSONL transcripts when context is compacted
- **Skills** — `/remember`, `/save-topic`, `/list-topics`
- **100% local** — Plain Markdown in `~/.memory/`, no database, no cloud

Built with bash + Node.js. MIT licensed. 115 script tests + 10 E2E tests passing.