### PR TITLE
Add defi-mcp — DeFi MCP server for token prices, wallets, and DEX quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [backend-architect](./backend-architect) - Backend architecture patterns, API design, database schemas, and system design.
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
+- [defi-mcp](https://github.com/OzorOwn/defi-mcp) - DeFi MCP server for Claude Desktop and Cursor. Real-time token prices, wallet balances across 9 chains, and DEX swap quotes via Model Context Protocol.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## Summary

Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the **Backend & Architecture** section.

## What it does

defi-mcp is a Model Context Protocol server that provides real-time DeFi data to Claude Desktop and Cursor:
- Token prices across major chains (ETH, SOL, BNB, etc.)
- Wallet balances for 9 blockchain networks
- DEX swap quotes from decentralized exchanges
- On-chain transaction lookups

## Why it belongs here

defi-mcp is a production MCP server that extends Claude with live blockchain data — it fits alongside `mcp-builder` and `agent-sdk-dev` as a backend integration for the DeFi/crypto domain. Open source, MIT licensed.