### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit. Analyzes raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, and more) and generates a terminal-style HTML dashboard.
 
 ### Image Generation
 


### PR DESCRIPTION
Added [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Developer Productivity section.

Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard. Built entirely with Claude Code.