### PR TITLE
Add PitchDocs to Documentation & Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Documentation & Security
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
+- [PitchDocs](https://github.com/littlebearapps/pitchdocs) - Documentation plugin with 14 skills and 12 commands. Scans codebases to extract features with file-level evidence and generates marketing-ready READMEs, CHANGELOGs, ROADMAPs, AI context files (AGENTS.md, CLAUDE.md, .cursorrules, and 4 more), and 20+ docs total. Includes GEO optimisation for AI citation, quality scoring (0-100), and Context Guard hooks. Works with 9 AI tools. MIT licensed.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 
 ### Developer Productivity


### PR DESCRIPTION
Adds [PitchDocs](https://github.com/littlebearapps/pitchdocs) to the Documentation & Security section.

PitchDocs is a documentation plugin with 14 skills and 12 commands that scans codebases, extracts features with file-level evidence, and generates marketing-ready docs. It differs from the existing `documentation-generator` entry by offering:

- **14 specialised skills** covering README, CHANGELOG, ROADMAP, user guides, AI context files, llms.txt, launch artifacts, and more
- **Evidence-based feature extraction** across 10 signal categories
- **AI context file generation** — AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md
- **GEO optimisation** for AI citation
- **Quality scoring** (0–100) with CI-friendly output
- **Context Guard hooks** for drift detection

Pure Markdown, zero runtime dependencies, MIT licensed. Works with 9 AI coding tools.