### PR TITLE
Add PM AI Partner: 12 PM-specific agent skills + 6 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [pm-ai-partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) - 12 PM-specific agent skills, 6 workflow commands, 3 automation hooks, and 17 MCP server configs for Product Managers. Install: `npx pm-ai-partner@latest`. ([npm](https://www.npmjs.com/package/pm-ai-partner))
 
 ### Image Generation
 


### PR DESCRIPTION
## Summary

Adds [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) to the Developer Productivity section.

**PM AI Partner** is a Claude Code plugin built for Product Managers, providing:
- 12 PM-specific agent skills (thought-partner, technical-analyst, writer, devil's advocate, etc.)
- 6 workflow commands (product-brief, meeting-prep, stakeholder-update, strategic-clarity, etc.)
- 3 automation hooks
- 17 MCP server configurations

### Install

```bash
npx pm-ai-partner@latest
```

### Links

- **GitHub**: https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework
- **npm**: https://www.npmjs.com/package/pm-ai-partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)