### PR TITLE
Add preflight to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server that catches vague prompts before they cost you 2-3x in wrong→fix cycles. Scores prompts across 12 categories, learns from past corrections, estimates token cost, and provides semantic search across session history with LanceDB vectors. `npx preflight-dev` to get started.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [preflight](https://github.com/preflight-dev/preflight) — a 24-tool MCP server for Claude Code that catches ambiguous prompts before they waste tokens on wrong→fix cycles.

**What it does:**
- Scores prompts across 12 categories before execution
- Learns from past correction patterns to prevent repeated mistakes
- Estimates token cost and waste from vague prompts
- Provides semantic search across session history via LanceDB vectors
- Cross-service contract awareness for multi-project setups

**Install:** `npx preflight-dev`

Built after analyzing 512 real Claude Code sessions (32K+ events, 3,200 prompts) — found ~30-40% of tokens wasted on avoidable back-and-forth from ambiguous prompts.

Category: Code Quality & Testing