### PR TITLE
Add ContextDocs to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
+- [ContextDocs](https://github.com/littlebearapps/contextdocs) - Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## Summary

Adds [ContextDocs](https://github.com/littlebearapps/contextdocs) to the Documentation & Security section.

Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools.

- **License:** MIT
- **Pure Markdown** — zero runtime dependencies
- **Install:** `/plugin add https://github.com/littlebearapps/lba-plugins`