### PR TITLE
Add claude-code-notify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
+- [claude-code-notify](https://github.com/JadenChoi2k/claude-code-notify) - Zero-dependency desktop notification hooks for Claude Code using native OS notifications (macOS/Linux). Clickable alerts, notification grouping, and one-command install in ~3 KB.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 
 ### Image Generation


### PR DESCRIPTION
## Summary

Adds [claude-code-notify](https://github.com/JadenChoi2k/claude-code-notify) to the **Developer Productivity** category.

- Zero-dependency desktop notification system for Claude Code
- Uses native OS notifications via hooks (macOS terminal-notifier/osascript, Linux notify-send)
- Clickable notifications, notification grouping, one-command curl install
- Total footprint ~3 KB, MIT licensed

## What problem it solves

When running long Claude Code tasks, users switch to other apps and miss when Claude finishes or needs input. This hooks-based plugin sends native desktop notifications automatically.

## Changes

- Added entry to README.md under Developer Productivity

![Demo](https://raw.githubusercontent.com/JadenChoi2k/claude-code-notify/main/assets/demo.png)