### PR TITLE
Add bitcoin-companies-skills to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills) - Query Bitcoin company treasury data. Search by name or domain, browse the leaderboard with filters (category, country, tier), and generate aggregate reports. Free API, no auth required.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds [bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills) to the Integrations section.

**What it does:** Claude Code plugin to query Bitcoin company treasury data from the [Bitcoin Companies API](https://bitcoincompanies.co/api-docs).

- `/bitcoin strategy.com` — company detail card
- `/bitcoin top 10 mining` — filtered leaderboard
- `/bitcoin report etf` — aggregate treasury report

Free API, no auth required, 629 companies tracked.