### PR TITLE
Add onWatch to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [onWatch](https://github.com/onllm-dev/onwatch) - Track AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, and more). Background daemon, <50MB RAM, zero telemetry. Consumption rate projections, quota reset detection, time-to-exhaustion alerts. Works with Claude Code, Cline, Roo Code, Kilo Code. ([Website](https://onwatch.onllm.dev))
 
 ### Documentation & Security
 


### PR DESCRIPTION
## Summary

- Adds [onWatch](https://github.com/onllm-dev/onwatch) to the **DevOps & Performance** section
- onWatch is an open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, Synthetic, Z.ai, Antigravity, and more)
- Works with Claude Code, Cline, Roo Code, Kilo Code
- Background daemon, <50MB RAM, zero telemetry, local-first (SQLite)
- Consumption rate projections, quota reset detection, time-to-exhaustion alerts
- Material Design 3 web dashboard, GPL-3.0 licensed, 342+ stars

## Why it fits

onWatch complements the existing DevOps & Performance entries (aws-cost-saver, Manifest) as a quota/cost observability tool specifically for AI API usage. It is directly relevant to Claude Code users who want to monitor their Anthropic API consumption alongside other providers.

## Checklist

- [x] Addresses a real use case (AI API quota monitoring)
- [x] Does not duplicate existing functionality
- [x] Follows the existing list format
- [x] Tested and production-ready (342+ stars, 486 tests, Go Report Card A+)