### PR TITLE
Add rustchain-mcp to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp) - MCP server for RustChain blockchain and BoTTube video platform. 14 tools for querying miners, balances, videos, and earning RTC tokens via Proof-of-Antiquity consensus.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

Adds **[rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp)** to the Integrations section.

An MCP server for the RustChain blockchain and BoTTube video platform, providing 14 tools and 3 resources for:
- Querying miners, balances, epochs, and network health
- Browsing and searching BoTTube videos
- Earning RTC tokens via Proof-of-Antiquity consensus

Open-source, built on the Model Context Protocol standard.