### PR TITLE
Add fractal — recursive project management plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [fractal](https://github.com/rmolines/fractal) - Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. Includes `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation.
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/rmolines/fractal) to the **Developer Productivity** section.

**What it does:** Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. The filesystem is the state — no database, no JSON.

**Key features:**
- `/fractal:run` — idempotent state machine, call repeatedly to advance the tree
- `/fractal:init` — bootstrap any goal into a predicate tree
- `/fractal:patch` — fast path for trivial leaf predicates
- Full sprint cycle: planning → delivery → review → ship
- Dry run mode — builds the full decomposition tree without executing
- Incremental decomposition with re-evaluation at each node

**Repo:** https://github.com/rmolines/fractal