### PR TITLE
Add product-manager-skills to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent skill for Claude Code. Covers 6 knowledge domains, 30+ product frameworks, and 32 SaaS metrics. Pure Markdown, no dependencies.
 
 ### Image Generation
 


### PR DESCRIPTION
Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Developer Productivity section.

This is a senior PM agent skill for Claude Code that brings structured product management knowledge — 6 domains (strategy, growth, analytics, etc.), 30+ frameworks, and 32 SaaS metrics. Pure Markdown, no dependencies, MIT-0 licensed.

Useful for anyone doing product work inside Claude Code and wanting consistent PM frameworks without having to prompt-engineer them each time.