### PR TITLE
Add iris-eval/mcp-server to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [iris-eval](https://github.com/iris-eval/mcp-server) - MCP-native agent eval & observability. Log traces, evaluate output quality (PII, injection, hallucination, cost), and track per-agent costs. Zero code changes.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adding [Iris](https://github.com/iris-eval/mcp-server) — MCP-native eval and observability. 12 eval rules, trace logging, cost tracking. MIT licensed.