### PR TITLE
Add cup - ClickUp CLI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, comments, sprints, time tracking, and more. Interactive tables in TTY, Markdown when piped, JSON with `--json`. Ships as a Claude Code plugin with skill files.
 
 ### Image Generation
 


### PR DESCRIPTION
Adds [cup](https://github.com/krodak/clickup-cli) to the Developer Productivity section. It's a ClickUp CLI that works as a Claude Code plugin - ships with `.claude-plugin` manifest and skill files. 40+ commands, three output modes (interactive tables, Markdown for piped output, JSON).

npm: [@krodak/clickup-cli](https://www.npmjs.com/package/@krodak/clickup-cli)