### PR TITLE
Add AgenTopology plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [agentopology](https://github.com/agentopology/agentopology) - Design multi-agent teams in plain English. Type `/agentopology` to generate `.at` topologies with agents, flows, gates, hooks, and group chats. Interactive visualizer. Scaffolds to 7 platforms. Apache 2.0.
 
 ### Image Generation
 


### PR DESCRIPTION
## Summary

- Adds [AgenTopology](https://github.com/agentopology/agentopology) to the **Developer Productivity** section
- AgenTopology is a Claude Code skill (`/agentopology`) for designing multi-agent systems in plain English — generates `.at` topology files with agents, flows, gates, hooks, and group chats, includes an interactive visualizer, and scaffolds to 7 platforms
- Apache 2.0 licensed