### PR TITLE
Add claude-scaffold — npx CLI for deploying Claude Code configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [claude-scaffold](https://github.com/pyramidheadshark/claude-scaffold) - npx CLI that deploys CLAUDE.md, hooks, and 18 domain skills to any repository in one command. Skills auto-activate via hooks based on project context. Cross-repo sync with `update --all`.
 
 ### Image Generation
 


### PR DESCRIPTION
Adding claude-scaffold to the Developer Productivity section.

claude-scaffold is an npx CLI that deploys a complete Claude Code setup (CLAUDE.md, hooks, skills, agents) to any repository in one command. 18 domain skills auto-activate via UserPromptSubmit hooks based on project context — working in a repo with FastAPI routes loads `fastapi-patterns`, LangGraph code loads `langgraph-patterns`, etc. Cross-repo sync via `npx claude-scaffold update --all`.

- GitHub: https://github.com/pyramidheadshark/claude-scaffold
- npm: https://npmjs.com/package/claude-scaffold