### PR TITLE
Add claude-memory-manager — Web UI for Claude Code memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Web UI for managing Claude Code's native MEMORY.md memory system. Three-panel interface for browsing, editing, and organizing cross-session memories with full operation reversibility.
 
 ### Image Generation
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
-- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Web UI for managing Claude Code's native MEMORY.md memory system. Three-panel interface for browsing, editing, and organizing cross-session memories with full operation reversibility.
+- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Adds a global memory layer to Claude Code. Memories are per-project by default; this plugin stores cross-project memories in ~/.claude/memory/ and injects them at session start. Ships a web UI for managing all memory files in one place.
 
 ### Image Generation
 


### PR DESCRIPTION
## What is claude-memory-manager?

Claude Code only stores memories per project. Fix a behavior in project A, project B doesn't know. This plugin adds a global memory layer (`~/.claude/memory/`) so cross-project preferences, corrections, and context carry over everywhere.

### How it works
- SessionStart hook injects global memories into every conversation
- Built-in skill lets Claude read/write global memories mid-session
- Web UI (localhost:5050) for browsing and editing all memories — global and per-project — in one place

### Screenshots

<table>
<tr>
<td width="50%" align="center"><strong>Global memories injected at session start</strong></td>
<td width="50%" align="center"><strong>Web UI for browsing and editing memories</strong></td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/terminal.png" width="100%"></td>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/webui.png" width="100%"></td>
</tr>
</table>

### Links
- GitHub: https://github.com/WhymustIhaveaname/claude-memory-manager
- License: MIT

### Category
Developer Productivity