### PR TITLE
Add Skillfold to Developer Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [Skillfold](https://github.com/byronxlg/skillfold) - YAML compiler for multi-agent pipelines. Composes skills, validates typed state, generates orchestrators from team flow definitions. Compiles to the Agent Skills standard. Includes Claude Code plugin with 11 library skills and `/skillfold` slash command. ([npm](https://www.npmjs.com/package/skillfold))
 
 ### Image Generation
 


### PR DESCRIPTION
## Summary

- Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Developer Productivity section in README.md

Skillfold is a YAML compiler for multi-agent AI pipelines. It composes atomic skills into agents, validates typed state schemas, and generates orchestrators from team flow definitions with conditional routing, loops, and parallel maps. Output compiles to the Agent Skills standard (SKILL.md files), supporting 12 platforms including Claude Code, Cursor, Codex, and Gemini CLI.

It includes a Claude Code plugin with 11 library skills (planning, research, code-writing, code-review, testing, etc.) and a `/skillfold` slash command.

- npm: [skillfold](https://www.npmjs.com/package/skillfold)
- Docs: [skillfold.dev](https://byronxlg.github.io/skillfold/)
- GitHub: [byronxlg/skillfold](https://github.com/byronxlg/skillfold)