### PR TITLE
Add kasetto to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [kasetto](https://github.com/pivoshenko/kasetto) - A declarative AI agent environment manager, written in Rust.
 
 ### Image Generation
 


### PR DESCRIPTION
Hey there! 👋

This PR adds [kasetto](https://github.com/pivoshenko/kasetto) to the **Developer Productivity** section.

kasetto is a declarative AI skills manager written in Rust. One YAML config syncs skills from GitHub repos (or local directories) into Claude Code and 35+ other agent environments. It tracks every install in a local SQLite manifest, supports `--dry-run` and `--json` for CI, and ships as a single binary.

Thank you for reviewing this! 🙏