### PR TITLE
Add prompt-chime notification plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [prompt-chime](https://github.com/pick/prompt-chime) - Cross-platform notification plugin with meme sound presets (Mario 1-Up, Zelda secret, Metal Gear alert), toast notifications, profiles, quiet hours, and per-project overrides. Includes a `/notification-toolkit` skill.
 
 ### Image Generation
 

--- a/marketplace.json
+++ b/marketplace.json
@@ -171,6 +171,13 @@
       "description": "Analyze coding patterns and get personalized learning resources",
       "author": "Composio",
       "tags": ["productivity", "learning", "growth", "analytics"]
+    },
+    {
+      "name": "prompt-chime",
+      "category": "productivity",
+      "description": "Cross-platform notification sounds and toast alerts when prompts complete, with meme presets, profiles, and quiet hours",
+      "author": "pick",
+      "tags": ["notifications", "sounds", "alerts", "productivity", "hooks"]
     }
   ],
   "categories": [

--- a/prompt-chime/.claude-plugin/plugin.json
+++ b/prompt-chime/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "prompt-chime",
+  "version": "1.2.0",
+  "description": "Cross-platform notification toolkit — get alerted when prompts complete with customizable sounds, toast notifications, profiles, and quiet hours.",
+  "author": {
+    "name": "pick",
+    "url": "https://github.com/pick"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pick/prompt-chime"
+  },
+  "license": "MIT",
+  "keywords": ["notifications", "sounds", "alerts", "productivity"],
+  "hooks": "../hooks/hooks.json",
+  "skills": "../skills/"
+}

--- a/prompt-chime/hooks/hooks.json
+++ b/prompt-chime/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/notify.sh\" --event stop",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/prompt-chime/skills/notification-toolkit/SKILL.md
+++ b/prompt-chime/skills/notification-toolkit/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: notification-toolkit
+description: Manage Prompt Chime notification sounds, profiles, quiet hours, and per-project overrides. Use when the user asks about notifications, sounds, alerts, or wants to customize what happens when a prompt completes.
+---
+
+# Prompt Chime Notification Toolkit
+
+You have access to a notification management CLI at `${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh`.
+
+## Available Commands
+
+Run these via bash:
+
+| Command | Description |
+|---------|-------------|
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" list` | List available sounds |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" preview <sound>` | Play a sound |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" set <event> <sound>` | Set sound for event (stop\|error\|long_running) |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" profile list` | List profiles |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" profile use <name>` | Switch active profile |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" profile create <name> [sound] [volume]` | Create a profile |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" project set <path> <sound>` | Set per-project sound |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" project remove <path>` | Remove project override |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" volume <0-100>` | Set volume |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" quiet on\|off [start] [end]` | Toggle quiet hours |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" toast on\|off` | Toggle toast notifications |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" status` | Show current settings |
+| `bash "${CLAUDE_PLUGIN_ROOT}/scripts/manage.sh" test` | Fire a test notification |
+
+## How It Works
+
+- A **Stop hook** fires `notify.sh` every time the assistant finishes responding
+- `notify.sh` reads config, detects the OS, and plays the appropriate sound + toast
+- Works on **Windows** (PowerShell MCI + WinRT toast), **macOS** (afplay + osascript), and **Linux** (paplay/aplay + notify-send)
+- Users can drop custom `.wav`/`.mp3` files in `sounds/custom/`
+
+## When Users Ask About Notifications
+
+- "Change my notification sound" → `manage.sh set stop <sound>` or `manage.sh profile use <name>`
+- "Turn off notifications" → `manage.sh toast off` or edit config `enabled: false`
+- "Make it quieter at night" → `manage.sh quiet on 22:00 08:00`
+- "Different sound for this project" → `manage.sh project set <path> <sound>`
+- "What sounds are available?" → `manage.sh list`


### PR DESCRIPTION
## Summary

Adds **prompt-chime** — a cross-platform notification plugin that plays sounds and toast notifications when Claude finishes responding.

## What's included

- `prompt-chime/` plugin folder with standard structure (`.claude-plugin/plugin.json`, `skills/`, `hooks/`)
- README entry under Developer Productivity
- `marketplace.json` entry

## Plugin features

- Stop hook fires OS-native audio (Win32 MCI on Windows, afplay on macOS, paplay/aplay on Linux)
- Toast notifications (WinRT, osascript, notify-send)
- 11 chiptune meme sound presets (Mario 1-Up, Zelda secret, Metal Gear alert, etc.)
- Sound profiles, quiet hours, per-project overrides
- `/notification-toolkit` skill for in-session management
- Zero dependencies, MIT licensed

## Quality checklist

- [x] Addresses a real use case (knowing when Claude finishes)
- [x] Doesn't duplicate existing functionality
- [x] Follows the template structure
- [x] Has been tested (54 E2E tests pass)

https://github.com/pick/prompt-chime