### PR TITLE
Add Pan Out

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
+- [pan-out](https://github.com/alexeyv/pan-out) - AI cooking companion plugin for Claude Code. Four skills handle the full arc — research the science, build a protocol, guide the cook with voice and timers, debrief afterward to improve next time.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 


### PR DESCRIPTION
[Pan Out](https://github.com/alexeyv/pan-out) is a Claude Code plugin for cooking. It provides four skills that cover the full arc of preparing a dish:

- **`/recipe`** -- research the science behind a dish and build a step-by-step protocol
- **`/cook`** -- guide you through the cook in real time with voice callouts, timers, and sensory checkpoints
- **`/debrief`** -- analyze what happened after the cook and capture lessons for next time
- **`/help`** -- onboarding and reference

It is a non-trivial example of a domain-specific (non-dev) plugin that demonstrates how skills, CLAUDE.md conventions, and structured markdown protocols can work together.

Added to the **Developer Productivity** section alphabetically.