### PR TITLE
Add Audio & Music section with claude-ai-music-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.
 
+### Audio & Music
+
+- [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - AI music album production plugin. Full-lifecycle coverage from concept planning and lyric writing through per-stem mixing, mastering, and release distribution.
+
 ## Getting Started
 
 ### Using Plugins


### PR DESCRIPTION
Proposes a new **Audio & Music** section and adds [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) as the first entry.

AI music album production plugin for Claude Code. Full-lifecycle coverage from concept planning and lyric writing through per-stem mixing, mastering, and release distribution.