### PR TITLE
Add The Pragmatic PM — PM leadership toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [the-pragmatic-pm](https://github.com/marfoerst/the-pragmatic-pm) - PM leadership toolkit with 43 skills, 5 orchestrator agents, and 4 multi-stage workflows for product teams. Covers PRD generation, OKR lifecycle, pricing strategy, competitive intelligence, sales enablement, and quarterly planning. Domain-agnostic customization via domain-context.md.
 
 ### Image Generation
 


### PR DESCRIPTION
## Add The Pragmatic PM

### What it does

A Claude Code plugin for product leadership — 43 skills + 5 agents + 4 workflows.

### Key capabilities

- **PRD generation** with 4 modes (Full, Lightweight, V2, Migration/Compliance)
- **OKR lifecycle** with 5 modes (Define, Refine, Check-in, Score, Align)
- **Pricing strategy** including dedicated AI feature pricing
- **Sales enablement** — battlecards, messaging frameworks, objection playbooks, sales decks
- **Quarterly planning** — full cycle from strategic review to roadmap
- **Competitive intelligence** — SWOT, market sizing, competitor profiles, positioning

### Quality standards

Every skill enforces: problem-first thinking, leading + lagging metrics, scope discipline, and compliance awareness. Built on Dunford (positioning), Ramanujam & Tacke (pricing), and Simon-Kucher (AI pricing) methodology.

**Repository:** https://github.com/marfoerst/the-pragmatic-pm