### PR TITLE
Add CoinPaprika & DexPaprika crypto data plugins to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [coinpaprika-skills](https://github.com/coinpaprika/skills) - Two crypto data plugins: CoinPaprika (12K+ coins, 350+ exchanges, OHLCV, tickers) and DexPaprika (34 chains, 30M+ DEX pools, real-time streaming). Free, no API key.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds one line to the Integrations section for coinpaprika-skills, a repo with two crypto data plugins:

- CoinPaprika: 12,000+ coins, 350+ exchanges, tickers, OHLCV.
- DexPaprika: DEX pools and tokens across 36 chains, plus SSE streaming.

Both run on a free tier and need no API key to start. The free tier is metered, current limits are on https://dexpaprika.com/api/pricing.

Source: [github.com/coinpaprika/skills](https://github.com/coinpaprika/skills)
