### PR TITLE
Add ultraship — all-in-one builder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [ultraship](https://github.com/Houseofmvps/ultraship) - All-in-one builder plugin — 29 tools, 32 skills, 9 agents. Full lifecycle: audit, ship, launch, grow, rescue. SEO/GEO/AEO, Lighthouse, security, competitive analysis, incident response.
 
 ### Documentation & Security
 


### PR DESCRIPTION
## Summary

Adds [ultraship](https://github.com/Houseofmvps/ultraship) to the DevOps & Performance section.

**ultraship** is an all-in-one builder plugin for Claude Code with 29 tools, 32 skills, and 9 agents. It covers the full product lifecycle — audit, ship, launch, grow, and rescue — including SEO/GEO/AEO optimization, Lighthouse performance audits, security scanning, competitive analysis, and incident response.

Published on npm as `ultraship` (free).

## Checklist

- [x] Plugin addresses a real use case
- [x] Doesn't duplicate existing functionality
- [x] Has been tested
- [x] README updated with plugin details

🤖 Generated with [Claude Code](https://claude.com/claude-code)