### PR TITLE
Add claude-token-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [claude-token-analyzer](https://github.com/li195111/claude-token-analyzer) - Diagnoses token waste in Claude Code sessions with 6 anomaly types and severity scoring. Fully local — one command install.
 
 ### Documentation & Security
 


### PR DESCRIPTION
## New Plugin: claude-token-analyzer

Diagnoses token waste in Claude Code sessions with 6 anomaly types, cost audit, and trend forecasting.

- **Install:** `claude plugin install claude-token-analyzer`
- **Fully local** — parses ~/.claude JSONL files into SQLite, nothing leaves your machine
- **MIT licensed**

GitHub: https://github.com/li195111/claude-token-analyzer
