### PR TITLE
Add Claudebase to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
+- [claudebase](https://github.com/rohithzr/claudebase) - Back up, restore, and sync your Claude Code config to a private GitHub repo. Named profiles for switching between setups, secret scanning, multi-machine conflict detection, and automatic backups. Uses gh CLI for auth.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 
 ### Image Generation


### PR DESCRIPTION
Adds [Claudebase](https://github.com/rohithzr/claudebase) - a Claude Code plugin that backs up, restores, and syncs your entire Claude Code environment to a private GitHub repo.

Features:
- 6 skills: setup, push, pull, status, profiles, config
- Named profiles for switching between work/personal/team setups
- Secret scanning (API keys, PEM files, tokens)
- Multi-machine conflict detection
- Automatic backups before every pull
- 158 BATS tests, CI on macOS/Linux/Windows
- MIT licensed