### PR TITLE
Add operant-mcp to Documentation & Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Open-source MCP server with 51 security testing tools for pentesting, vulnerability scanning, and security auditing. MIT licensed.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Documentation & Security section.

- Open-source MCP server with 51 security testing tools
- Covers pentesting, vulnerability scanning, and security auditing
- MIT licensed

## Details

operant-mcp brings comprehensive security testing capabilities into your Claude workflow through 51 specialized tools including SQL injection testing, XSS detection, CORS misconfiguration checks, recon tools, PCAP analysis, authentication testing, and more.

- GitHub: https://github.com/operantlabs/operant-mcp
- License: MIT