### PR TITLE
Add claude-notify — notification center plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [claude-notify](https://github.com/dz1922/claude-notify) - Notification center for Claude Code. Get notified when background agents finish, tasks complete, or Claude is waiting for input. Supports desktop (macOS/Linux/Windows), Telegram, Slack, Teams, Lark, and custom webhooks. Zero config — desktop notifications work immediately after install.
 
 ### Image Generation
 


### PR DESCRIPTION
## Summary

Add [claude-notify](https://github.com/dz1922/claude-notify) to the Developer Productivity category.

**What it does:** Notification center for Claude Code — sends notifications when background agents finish, tasks complete, or Claude is waiting for input.

**Channels:** Desktop (macOS/Linux/Windows), Telegram, Slack, Microsoft Teams, Lark/Feishu, custom webhooks.

**Key feature:** Desktop notifications work immediately after install, zero configuration needed. Additional channels via `/notify:setup`.

**28 tests passing.** All channels tested with real services.