### PR TITLE
Add cc-hud statusline plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [cc-hud](https://github.com/WaterTian/cc-hud) - Compact single-line statusline plugin — displays model name, context window usage (1/8 precision progress bar), active subagents, and rate limits. Pure Node.js, zero dependencies, Catppuccin Mocha color theme.
 
 ### Image Generation
 


### PR DESCRIPTION
## Add cc-hud

Adds [cc-hud](https://github.com/WaterTian/cc-hud) to the **Developer Productivity** section.

**cc-hud** is a compact single-line statusline plugin for Claude Code that displays:
- Model name
- Context window usage with 1/8 precision progress bar
- Active subagents
- Rate limits (5h/7d)

Pure Node.js, zero dependencies, Catppuccin Mocha color theme. Available on npm as `cc-hud`.

**Install:**
```
/plugin marketplace add WaterTian/cc-hud && /plugin install cc-hud && /cc-hud:setup
```

- **GitHub:** https://github.com/WaterTian/cc-hud
- **npm:** https://www.npmjs.com/package/cc-hud
- **License:** MIT
- **Author:** WaterTian