### PR TITLE
Add codebase-graph and agntk

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
+- [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 
 ### Image Generation
 


### PR DESCRIPTION
## What
Adding two open-source AI developer tools to the Developer Productivity section:

- **[codebase-graph](https://github.com/Phoenixrr2113/codebase-graph)** — Code intelligence MCP server with 42-language tree-sitter AST parsing and FalkorDB knowledge graphs
- **[agntk](https://github.com/Phoenixrr2113/agntk)** — Zero-config CLI AI agent with 20+ built-in tools, Ollama auto-detection, and free tier

Both are MIT licensed, actively maintained, and published on npm.