### PR TITLE
Add claude-familiar plugin (Companion & Personality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Companion & Personality
 
-- [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Give the Claude Code companion a personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
+- [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
 
 ### Image Generation
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [DevOps & Performance](#devops--performance)
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
+  - [Companion & Personality](#companion--personality)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
 - [Resources](#resources)
@@ -142,6 +143,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+
+### Companion & Personality
+
+- [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Give the Claude Code companion a personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
 
 ### Image Generation
 


### PR DESCRIPTION
## What this adds

[claude-familiar](https://github.com/yaniv-golan/claude-familiar) — a plugin that gives the Claude Code companion a personality, mood, lore, and interactive commands.

### Features

- **Personality & traits** injected into every session via SessionStart hook
- **Mood engine** — 6 moods that shift automatically on tool success/failure and decay over time
- **Lore** — persistent backstory entries that accumulate across sessions
- **8 MCP tools** — fortune, roast, haiku, focus timer, stats, mood, lore, personality
- **Extensible** — other plugins can layer traits, lore, and mood modifiers by adding `"x-familiarExtensions"` to their `plugin.json`
- **Optional binary patch** — redirects the companion speech bubble to a local reaction server for fully in-character responses

### Category

Added a new **Companion & Personality** section since this doesn't fit existing categories — it's about customizing the companion experience rather than code quality, git workflows, or productivity tooling.

### Checklist

- [x] Addresses a real use case (companion customization)
- [x] Doesn't duplicate existing functionality
- [x] Has been tested (100 test cases, live Claude Code sessions)
- [x] MIT licensed

Made with [Cursor](https://cursor.com)