### PR TITLE
Add claude-debate-skills plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [claude-debate-skills](https://github.com/biyachuev/claude-debate-skills) - Structured two-voice AI debates between Claude and Codex for strategy validation, idea stress-testing, and decision pressure-testing. Three skills: strategy-debate, creator-critic, and options-challenge.
 
 ### Image Generation
 


### PR DESCRIPTION
## Summary

- Adds [claude-debate-skills](https://github.com/biyachuev/claude-debate-skills) to the **Developer Productivity** section
- Plugin provides 3 skills (`strategy-debate`, `creator-critic`, `options-challenge`) that orchestrate structured two-voice AI debates between Claude (Anthropic) and Codex (OpenAI)
- Use cases: strategy validation, creative idea stress-testing, and decision pressure-testing
- MIT licensed, standard `.claude-plugin/plugin.json` format

## Details

The plugin enables a "debate" workflow where two different AI models argue opposing positions on a given topic, helping users surface blind spots, challenge assumptions, and reach more robust conclusions. Each skill targets a different decision-making scenario:

- **strategy-debate** — structured strategic analysis with alternating pro/con arguments
- **creator-critic** — idea generation followed by rigorous critique
- **options-challenge** — pressure-testing decision options from multiple angles

Repository: https://github.com/biyachuev/claude-debate-skills