### PR TITLE
Add backlog: persistent task management plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
+- [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
 ### Image Generation
 


### PR DESCRIPTION
Hey! I built [backlog](https://github.com/backloghq/backlog) — a persistent, cross-session task management plugin for Claude Code.

Claude Code sessions are ephemeral, so any task context dies with the conversation. Backlog bridges that gap with an MCP server that gives agents read/write access to a persistent task store. Tasks created in one session can be picked up in another.

**What it does:**
- 24 MCP tools for tasks, projects, tags, dependencies, annotations, and attached docs
- 7 skills: /plan, /standup, /handoff, /refine, /spec, /implement, /tasks
- Agent coordination — agents can assign, start, and complete tasks
- Event-sourced storage (append-only log with checkpoint recovery)
- Pure TypeScript, zero external dependencies beyond Node.js

**Install:**
```bash
claude plugin add backloghq/backlog
```

- Repo: https://github.com/backloghq/backlog
- Website: https://backloghq.io
- License: MIT