### PR TITLE
Add Maestro Orchestrate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [backend-architect](./backend-architect) - Backend architecture patterns, API design, database schemas, and system design.
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
+- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds [Maestro Orchestrate](https://github.com/josstei/maestro-orchestrate) to the Backend & Architecture section.

Maestro Orchestrate is a multi-agent development orchestration plugin for Claude Code that coordinates 22 specialized subagents through 4-phase workflows (Design → Plan → Execute → Complete). Features include:

- Native parallel subagent execution
- MCP server with 12 tools for session and workspace management
- Persistent session state across interruptions
- Least-privilege security with 4-tier agent access model
- Standalone slash commands: /orchestrate, /review, /debug, /security-audit, /perf-check, /seo-audit, /a11y-audit, /compliance-check
- Also runs on Gemini CLI and Codex