### PR TITLE
Add toprank to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads plugin. Connects Claude Code to Google Search Console, PageSpeed Insights, and Google Ads API. 9 skills: audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, pushes fixes to WordPress/Strapi/Contentful/Ghost. MIT, 100+ stars.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds **toprank** under Integrations, alongside connect-apps.

toprank is a Claude Code plugin that connects Claude to Google Search Console, PageSpeed Insights, and the Google Ads API. 9 skills covering SEO audits, keyword research, content writing, meta tag optimization, JSON-LD schema generation, CMS connectors (WordPress/Strapi/Contentful/Ghost), Google Ads campaign management, and RSA copy generation.

## Traction
- **107 GitHub stars**, **14 forks** (open-sourced recently)
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests
- Full per-skill reference documentation

- Source: https://github.com/nowork-studio/toprank
- Install: `/plugin marketplace add nowork-studio/toprank`