### PR TITLE
Add claude-ops — business operations plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [backend-architect](./backend-architect) - Backend architecture patterns, API design, database schemas, and system design.
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
-- [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
-- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.\n- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
 
 ### DevOps & Performance
 
@@ -143,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) - Business operating system plugin for Claude Code. Morning briefings, unified inbox, autonomous PR merge, infrastructure monitoring, and YOLO autonomous mode for hands-free operations.
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.


### PR DESCRIPTION
## What is claude-ops?

[claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) is a business operating system plugin for Claude Code. It turns Claude Code into a unified command center for business operations.

**Key features:**
- Morning briefings: aggregates GitHub PRs, Linear issues, Sentry errors, and calendar into a single digest
- Unified inbox: read and reply to Slack, Gmail, GitHub notifications from one interface
- Autonomous PR merge pipeline: reviews and merges approved PRs with safety checks
- Infrastructure monitoring: ECS Fargate health, AWS costs, deployment status
- YOLO autonomous mode: spawns parallel C-suite agents for hands-free operations

**Install:**
```bash
claude ops:setup
```

Fits naturally in the **Developer Productivity** section alongside tools like CCHub and backlog that extend Claude Code beyond pure coding tasks into workflow automation.