### PR TITLE
Add idea-to-deploy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy) - Complete project lifecycle methodology — 19 skills + 6 subagents. Product discovery (MoSCoW/RICE), planning, scaffolding, testing, security audit (Red/Blue Team), DB migrations, infra-as-code, session persistence, self-improving meta-review (23 gates).
 
 ### DevOps & Performance
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
-- [idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy) - Complete project lifecycle methodology — 19 skills + 6 subagents. Product discovery (MoSCoW/RICE), planning, scaffolding, testing, security audit (Red/Blue Team), DB migrations, infra-as-code, session persistence, self-improving meta-review (23 gates).
+- [idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy) - Complete project lifecycle methodology — 19 skills + 6 subagents. Product discovery (MoSCoW/RICE), planning, scaffolding, testing, security audit (Red/Blue Team), DB migrations, infra-as-code, session persistence, self-improving meta-review (23 gates).
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## What

Adds [idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy) to the **Backend & Architecture** section.

## Plugin summary

Complete project lifecycle methodology for Claude Code — from product discovery to production deploy.

- **19 skills**: `/kickstart`, `/blueprint`, `/guide`, `/task`, `/bugfix`, `/refactor`, `/doc`, `/test`, `/perf`, `/review`, `/explain`, `/session-save`, `/security-audit`, `/deps-audit`, `/migrate`, `/harden`, `/infra`, `/project`, `/session-save`
- **6 subagents**: architect, code-reviewer, doc-writer, perf-analyzer, test-generator, security-auditor
- Product discovery (MoSCoW / RICE prioritization)
- Self-improving meta-review with 23 binary gates across 3 tiers
- Session persistence and parallel-session awareness
- MIT license, v1.17.2

## Checklist

- [x] Entry matches existing README format
- [x] Plugin addresses a real use case (full lifecycle, not covered by existing plugins)
- [x] No duplication — existing plugins cover individual tasks; this is a unified methodology
- [x] Tested and actively maintained

---
**Update 2026-04-20:** Repository transferred to `hihol-labs` org. All URLs updated in this PR. GitHub redirect from old path still works.
