### PR TITLE
Add StyleSeed — design engine with 11 Claude Code slash-command skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
-- [StyleSeed](https://github.com/bitjaru/styleseed) - Design engine for Claude Code and Cursor. 11 slash-command skills (`ss-component`, `ss-page`, `ss-pattern`, `ss-a11y`, `ss-audit`, `ss-review`, `ss-lint`, etc.) with 69 design rules, 48 shadcn-style React components, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion) on Tailwind CSS v4 + Radix UI.
+- [StyleSeed](https://github.com/bitjaru/styleseed) - Claude Code plugin: 11 design-rule slash commands with 48 React components.
 
 ### Git & Version Control
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [StyleSeed](https://github.com/bitjaru/styleseed) - Design engine for Claude Code and Cursor. 11 slash-command skills (`ss-component`, `ss-page`, `ss-pattern`, `ss-a11y`, `ss-audit`, `ss-review`, `ss-lint`, etc.) with 69 design rules, 48 shadcn-style React components, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion) on Tailwind CSS v4 + Radix UI.
 
 ### Git & Version Control
 


### PR DESCRIPTION
Adding **StyleSeed** to the Frontend & Design section.

**Link:** https://github.com/bitjaru/styleseed

StyleSeed is a design engine that makes Claude Code and Cursor produce professional UI:
- **11 slash-command skills**: `/ss-component`, `/ss-page`, `/ss-pattern`, `/ss-a11y`, `/ss-audit`, `/ss-review`, `/ss-lint`, `/ss-tokens`, `/ss-copy`, `/ss-feedback`, `/ss-flow`, `/ss-setup`
- **69 documented design rules** — card hierarchy, typography scale, spacing rhythm, accessibility
- **48 shadcn-style React components** (Tailwind CSS v4 + Radix UI)
- **Swappable brand skins**: Toss, Stripe, Linear, Vercel, Notion
- MIT licensed

It addresses a specific gap: AI tools generate functional UI, but not *professionally-judged* UI. StyleSeed encodes design judgment as enforceable rules the LLM can follow.