### PR TITLE
Add 8-habit-ai-dev to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
+- [8-habit-ai-dev](https://github.com/pitimon/8-habit-ai-dev) - Anti-Vibe-Coding workflow discipline plugin — 17 skills implementing a 7-step development workflow grounded in Covey's 8 Habits. DAG-validated skill chain, 472 automated assertions, Whole Person Model assessment, maturity-adaptive verbosity. Pure markdown, zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.


### PR DESCRIPTION
## Plugin: 8-habit-ai-dev

**Repository**: https://github.com/pitimon/8-habit-ai-dev
**Category**: Developer Productivity
**License**: MIT
**Version**: 2.8.0

### What it does

Anti-Vibe-Coding workflow discipline plugin for Claude Code — 17 skills implementing a 7-step development workflow grounded in Stephen Covey's 8 Habits. Pure markdown, zero dependencies, 472 automated assertions.

### Why it fits Developer Productivity

- Enforces `/requirements` before building and `/review-ai` before committing — the two habits that eliminate most vibe coding problems
- DAG-validated skill chain ensures workflow steps execute in order
- Whole Person Model assessment (Body/Mind/Heart/Spirit) catches AI blind spots
- Maturity-adaptive: adapts verbosity from beginner (full guidance) to senior (key checkpoints)

### Install

```bash
claude plugin marketplace add pitimon/8-habit-ai-dev
claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev
```