### PR TITLE
Add whatsapp-claude-plugin to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) - WhatsApp channel plugin for Claude Code — officially published on the Anthropic Plugin Marketplace. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

- Adds [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) to the **Integrations** section of the README.
- This plugin connects Claude Code to WhatsApp as a linked device via Baileys v7, providing bidirectional messaging, full media support, voice transcription (Whisper), permission relay, and access control.
- Officially published on the Anthropic Plugin Marketplace.

## Plugin details

| Field | Value |
|-------|-------|
| Name | whatsapp-claude-plugin |
| Repo | https://github.com/Rich627/whatsapp-claude-plugin |
| Author | Richie Liu (Rich627) |
| Category | Integrations |

## Checklist

- [x] Addresses a real use case (WhatsApp messaging channel for Claude Code)
- [x] Does not duplicate existing functionality
- [x] Has been tested
- [x] README updated with plugin entry in correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)