### PR TITLE
Add zetetic-team-subagents plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents) - 97 genius reasoning patterns (Feynman, Dijkstra, Pearl, Turing, etc.) + 18 team specialists, 63 skills, 14 hooks. Every agent enforces a zetetic epistemic standard — claims must cite sources, unsourced constants are blocked at commit time. Includes shape-based problem routing, deep research workflows, systematic reviews, and per-agent model overrides via `setup.sh configure`. Pairs with [Cortex](https://github.com/cdeust/Cortex) for persistent memory.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## Summary

Adds [zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents) to **Backend & Architecture**. 97 genius reasoning patterns + 18 team specialists, 63 skills, 14 hooks. Zetetic epistemic standard, shape-based routing, per-agent model overrides. Pairs with [Cortex](https://github.com/cdeust/Cortex) for persistent memory.

## Checklist
- [x] Entry follows existing format
- [x] Plugin tested with Claude Code v2.2.0
- [x] Doesn't duplicate existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)