### PR TITLE
Add Helium MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [backend-architect](./backend-architect) - Backend architecture patterns, API design, database schemas, and system design.
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Real-time news intelligence, market data, ML options pricing, and media bias analysis via MCP.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
 


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the Backend & Architecture section. Helium provides real-time news intelligence, market data, ML options pricing, and media bias analysis through MCP.

Made with [Cursor](https://cursor.com)