### PR TITLE
Add ESP32-AI-Agent-Skill plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [ESP32-AI-Agent-Skill](https://github.com/ezrover/ESP32-AI-Agent-Skill) - ESP32 embedded systems expert with chip selection across 9 variants, GPIO validation with anti-bricking safety checks, Arduino/ESP-IDF code generation, LVGL v8-v9.5 references, and 60+ Waveshare board pinouts.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds ESP32-AI-Agent-Skill under Backend & Architecture — the first hardware/embedded systems plugin in this collection.

- GPIO pin validation with safety checks preventing hardware damage
- Code generation for Arduino and ESP-IDF
- 9 ESP32 variants, LVGL UI, 60+ Waveshare boards
- MIT licensed, 50 automated tests

Repo: https://github.com/ezrover/ESP32-AI-Agent-Skill