### PR TITLE
Add llm-wiki plugin to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build a compounding, LLM-curated personal knowledge base in any project — Andrej Karpathy's LLM Wiki pattern. Skill + 5 `/wiki:*` commands (init, ingest, query, lint, stats) with sharded indexes, BM25 search, and a structural lint script. Designed to scale to thousands of pages without becoming a context bottleneck.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) under **Developer Productivity**.

## What it does

Claude Code plugin that builds a compounding, LLM-curated personal knowledge base inside any project — an implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Ingested sources (papers, articles, transcripts, PDFs, notes) are compiled once into persistent, structured markdown pages; subsequent queries read the pre-synthesized wiki rather than re-chunking raw sources, so knowledge compounds.

## What's in the plugin

- `llm-wiki` skill (progressive-disclosure references for architecture, ingest, query, lint, scaling)
- 5 slash commands: `/wiki:init`, `/wiki:ingest`, `/wiki:query`, `/wiki:lint`, `/wiki:stats`
- 4 bundled Python scripts (stdlib only): init, BM25 search with frontmatter filters, structural lint, size/shape stats
- Marketplace manifest — installable via `/plugin marketplace add praneybehl/llm-wiki-plugin` or `npx skills add praneybehl/llm-wiki-plugin`

## Checklist

- [x] Addresses a real use case (scalable, LLM-maintained research notes / second brain that avoids RAG's "nothing accumulates" failure mode)
- [x] Doesn't duplicate existing entries in the list
- [x] Follows the list's entry format
- [x] Tested — validated with `claude plugin validate .`, installed locally, and all five commands exercised