### PR TITLE
Add claude-code-sessions to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) - Session intelligence plugin. 11 skills for full-text search, token analytics, task management, session comparison, timeline views, and context recovery across all Claude Code sessions. Includes a web dashboard with four views. Same TypeScript modules power skills, dashboard, and CLI. Zero runtime dependencies, read-only.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Adds [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) to the Developer Productivity section.

Session intelligence plugin with 11 skills:

- `/session-search` — full-text search across every session
- `/session-stats` — token usage, model distribution, tool breakdown
- `/session-list` — list sessions sorted by recency, size, or duration
- `/session-detail` — deep dive into a specific session
- `/session-diff` — compare two sessions (files, tools, topics)
- `/session-timeline` — chronological view of sessions on a project
- `/session-resume` — generate a context recovery prompt from any session
- `/session-tasks` — find pending and orphaned tasks across sessions
- `/session-export` — export a session as clean markdown
- `/session-cleanup` — find empty, tiny, or stale sessions
- `/session-delete` — delete sessions and their associated tasks

Plus a web dashboard with four views (Dashboard, Sessions, Search, Tasks).

Same TypeScript modules power skills, dashboard, and CLI. Zero runtime dependencies. Read-only — never writes to Claude Code data. MIT licensed.

Install: `claude plugin add apappascs/claude-code-sessions`