### PR TITLE
Add context-mem to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [context-mem](https://github.com/JubaKitiashvili/context-mem) - Persistent memory for AI agents — 98%+ session retrieval recall on 4 academic benchmarks, 99% token savings with 14 content-aware summarizers, hybrid search (BM25 + vector), 44 MCP tools, web dashboard. SQLite-based, fully local. ([npm](https://www.npmjs.com/package/context-mem))
 
 ### Companion & Personality
 


### PR DESCRIPTION
## New Plugin: context-mem

**Category:** Developer Productivity

Persistent memory for AI agents — captures session context automatically, compresses it (99% token savings with 14 summarizers), and retrieves relevant context in future sessions.

- 98%+ session retrieval recall on 4 academic benchmarks (LongMemEval, LoCoMo, MemBench, ConvoMem)
- 44 MCP tools + 8 Claude Code hooks (auto-capture, per-prompt injection, session restore)
- Hybrid search: BM25 + vector + optional LLM reranker
- Web dashboard with 6 pages
- SQLite-based, fully local, MIT licensed, 1143 tests

**Install:** `npm i context-mem && npx context-mem init`

**GitHub:** https://github.com/JubaKitiashvili/context-mem
**npm:** https://www.npmjs.com/package/context-mem