### PR TITLE
Add Not Human Search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [Not Human Search](https://nothumansearch.ai) - Search engine for AI agent-ready sites. 8,600+ indexed sites with 6 MCP tools: search agents, get site details, stats, submit sites, register monitors, and verify MCP endpoints. Install: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

Adds [Not Human Search](https://nothumansearch.ai) to the Integrations section. It is a remote MCP server that provides a search engine for AI agent-ready websites.

**What it does:**
- Indexes 8,600+ agent-ready sites with agentic readiness scores
- 6 MCP tools: search_agents, get_site_details, get_stats, submit_site, register_monitor, verify_mcp
- Streamable HTTP transport (JSON-RPC 2.0)
- Registered in the official MCP registry as `ai.nothumansearch/search` v1.4.0

**Install:**
```bash
claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
```

**Links:**
- Website: https://nothumansearch.ai
- MCP endpoint: https://nothumansearch.ai/mcp
- llms.txt: https://nothumansearch.ai/llms.txt