### PR TITLE
Add MorningAI to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 free sources (Reddit, HN, GitHub, HuggingFace, arXiv, X). Generates scored daily reports with infographics and message digests. Invoke via `/morning-ai`.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

- Adds [MorningAI](https://github.com/octo-patch/MorningAI) to the **Developer Productivity** section
- AI news tracking skill that monitors 80+ entities across 6 free sources (Reddit, HN, GitHub, HuggingFace, arXiv, X/Twitter)
- Generates scored daily reports with infographics and message digests
- Invoke via `/morning-ai`, no API keys required
- MIT licensed, includes `.claude-plugin/plugin.json` manifest