### PR TITLE
Add AI Dev Jobs MCP server to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Integrations
 
+- [AI Dev Jobs](https://aidevboard.com) - AI/ML job board with 5,300+ positions and 4 MCP tools: search jobs, get job details, list companies, and get stats. Install: `claude mcp add --transport http aidevjobs https://aidevboard.com/mcp`
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 
 ### Frontend & Design


### PR DESCRIPTION
## Summary

Adds [AI Dev Jobs](https://aidevboard.com) to the Integrations section. It is a remote MCP server providing an AI/ML job board with 5,300+ positions.

**What it does:**
- 5,300+ AI/ML job listings with search, filtering, and company data
- 4 MCP tools: search_jobs, get_job, list_companies, get_stats
- Streamable HTTP transport (JSON-RPC 2.0)
- Registered in the official MCP registry as `com.aidevboard/jobs`

**Install:**
```bash
claude mcp add --transport http aidevjobs https://aidevboard.com/mcp
```

**Links:**
- Website: https://aidevboard.com
- MCP endpoint: https://aidevboard.com/mcp
- API docs: https://aidevboard.com/openapi.yaml
- GitHub: https://github.com/unitedideas/aidevboard-mcp