### PR TITLE
Add claude-snapshot to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-snapshot](https://github.com/adhenawer/claude-snapshot) - Portable Claude Code setup snapshots. Export your config, plugins, hooks, and global MDs as a `.tar.gz` and apply on another machine in under 2 minutes. Includes inspect/diff/apply commands with automatic backups — useful for syncing between machines, backing up before OS reinstall, or rolling back risky changes.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) to the **Developer Productivity** section.

claude-snapshot lets users export their entire Claude Code setup (config, plugins, hooks, global MDs) as a portable `.tar.gz` and apply it on another machine in under 2 minutes. It also ships `inspect` and `diff` commands and performs automatic `.bak` backups on `apply`.

Typical use cases:
- Syncing personal and work machines
- Backing up before an OS reinstall / Mac format
- Rolling back after risky plugin or config experiments
- Onboarding teammates to a shared setup

## Checklist

- [x] Addresses a real use case (multi-machine sync + safe rollback — no native equivalent today)
- [x] Doesn't duplicate existing functionality (closest entries like CCHub are desktop UIs; this is a pure CLI plugin focused on portable snapshots)
- [x] Follows the README entry format (external repo link under appropriate category)
- [x] Plugin tested locally (export → apply round-trip verified)

## Plugin info

- Repo: https://github.com/adhenawer/claude-snapshot
- License: MIT
- Install: `/plugin marketplace add adhenawer/claude-snapshot` then `/plugin install snapshot@claude-snapshot`