### PR TITLE
Add idle-timing to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [idle-timing](https://github.com/clankercode/claude-inject-idle-time) - Injects hidden timing context (local time with UTC offset, idle seconds since last reply, previous-turn duration) into every user prompt so the model knows how long the conversation has been paused. Ships a statusline fragment for a live elapsed-time readout and a visible `[after Xm Ys]` note when you return from >10s idle.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary
- Adds [idle-timing](https://github.com/clankercode/claude-inject-idle-time) to the Developer Productivity section
- Hooks-based plugin that injects hidden timing context (time, idle seconds, last-turn duration) into each user prompt so the model knows how long it's been paused
- Also surfaces elapsed time to the user via a statusline fragment and `[after Xm Ys]` re-entry notes

## Plugin details
- **License:** Unlicense/CC0 dual
- **Hooks:** UserPromptSubmit, Stop, PreCompact
- **Tests:** 57 passing
- **Install:** `/plugin marketplace add clankercode/claude-inject-idle-time` then `/plugin install idle-timing@idle-info`