### PR TITLE
Add idea-factory — AI company factory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [idea-factory](https://github.com/gguloadoong/idea-factory) - Template-install AI company factory for Claude Code. Describe a one-line idea, get a full virtual startup team (PM / Developer / Designer / Architect / Critic / Code-Reviewer / QA) that builds an MVP autonomously. Ships with MCP bundle (Supabase + Vercel, OAuth 2.1), 4-reviewer worktree gate, and MVP-First pipeline. MIT licensed.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Add idea-factory to Developer Productivity

**What it is**: [idea-factory](https://github.com/gguloadoong/idea-factory) is a Claude Code plugin that turns a one-line business idea into an autonomous MVP build. A full virtual startup team — PM, Developer, Designer, Architect, Critic, Code-Reviewer, QA-Tester — handles analysis, scaffolding, building, reviewing, and shipping.

**Why it belongs here**: It is a `claude plugin install`-ready plugin with a proper `.claude-plugin/plugin.json` manifest following the official plugins-reference schema. It ships an MCP bundle (Supabase + Vercel, OAuth 2.1 default), Routines cloud automation, and a 4-reviewer worktree gate — making it a substantial Developer Productivity addition to the catalog.

**Repo**: https://github.com/gguloadoong/idea-factory
**License**: MIT