### PR TITLE
Add claude-snapshot — portable setup snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-snapshot](https://github.com/adhenawer/claude-snapshot) - Portable Claude Code setup snapshots. Export settings, plugins, hooks, CLAUDE.md, and MCP configs as a `.tar.gz`. Diff before applying, restore on another machine in under 2 minutes. No network, `.bak` safety on every overwrite. Node.js 18+, macOS + Linux.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) to the **Developer Productivity** section.

**claude-snapshot** is a Claude Code plugin for exporting your entire setup (settings, plugins, hooks, CLAUDE.md, MCP configs) as a portable `.tar.gz` and restoring it on another machine — no GitHub repo, no network, just a local file.

**Commands:**
- `/snapshot:export` — capture setup as `.tar.gz`
- `/snapshot:apply` — restore with diff preview; every overwrite backed up as `.bak`
- `/snapshot:diff` — compare snapshot vs current before applying
- `/snapshot:inspect` — browse manifest without extracting

**Install:**
```bash
/plugin marketplace add adhenawer/claude-snapshot
/plugin install snapshot@claude-snapshot
```