### PR TITLE
Add Superpower Builder under Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) - Interview-driven meta-builder for Claude Code that turns recurring tasks into reusable plugins and skills, routed by kind (workflow, discipline, content, subagent) so each interview is specialist-tailored. Every generated skill is pressure-tested baseline-without-skill vs. with-skill before being saved, demonstrating behavior change. Ships 25 hand-crafted superpowers spanning dev (TDD, plan/execute) and non-dev (research, decisions, writing). Marketplace install: `/plugin marketplace add redhuntlabs/superpower-builder`. MIT, no telemetry.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What this adds

Adds [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) to the Developer Productivity section.

It's a meta-builder plugin for Claude Code: rather than a single skill, it interviews you about a recurring task, routes by skill kind (workflow, discipline, content, subagent), runs a kind-specific specialist interview, and pressure-tests the generated skill baseline-vs-with-skill before saving it to a personal library.

## Why "Developer Productivity"

Like `skill-bus`, `backlog`, and `CCHub`, it's a workflow/meta-tool that operates across all the user's other plugins rather than serving a specific domain. It complements other entries rather than overlapping any of them.

## Use case

A real recurring task — say "weekly CTEM triage" or "PR review against our React rubric" — becomes a tested, version-controlled SKILL.md in 5–15 minutes. Generated skills round-trip back to vanilla obra/superpowers format for portability, so contributors aren't locked in.

## Checklist (per CONTRIBUTING)

- [x] Addresses a real use case (turning ad-hoc workflows into reusable plugins/skills)
- [x] Doesn't duplicate existing functionality (no other plugin in the list is a meta-builder)
- [x] Follows the standard plugin structure (`.claude-plugin/plugin.json`, `skills/`, `commands/`, `agents/`, `hooks/`)
- [x] Tested — V1.0.0 shipped with adversarial-test gate in CI