### PR TITLE
Add claude-skills — 14-category autonomous product-building OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Backend & Architecture
 
 - [backend-architect](./backend-architect) - Backend architecture patterns, API design, database schemas, and system design.
+- [claude-skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 58 submodules and 9 agents. Ships complete products from one-line prompts on Cloudflare Workers with Angular, Hono, Stripe, SEO, accessibility, and visual QA. Install: `claude plugin install megabytespace/claude-skills`.
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.


### PR DESCRIPTION
## claude-skills — Autonomous Product-Building OS for Claude Code

**Install:** `claude plugin install megabytespace/claude-skills`
**Repo:** https://github.com/megabytespace/claude-skills
**Author:** Brian Zalewski / [Megabyte Labs](https://megabyte.space)
**License:** Rutgers License (pay what you think is fair)

### What It Does
Converts one-line prompts into fully deployed, production-ready products. Give it a domain name — it infers the product type, researches competitors, builds frontend + backend, deploys to Cloudflare Workers, runs E2E tests at 6 breakpoints, audits SEO and accessibility, generates media assets, and keeps improving until there's nothing left to improve.

### Architecture
- **14 skill categories** with 58 submodule capabilities
- **9 bundled agents** (architect, code-simplifier, completeness-checker, deploy-verifier, security-reviewer, seo-auditor, test-writer, visual-qa, computer-use-operator)
- **Data-driven:** Trained on 10,255 real engineering messages across 3,102 conversations
- **Decision model** with 4-gate technology evaluation framework

### Default Stack
Cloudflare Workers + Hono | Angular 19 + Ionic + PrimeNG | D1/Neon | Drizzle + Zod | Clerk | Stripe | Playwright + Vitest | PostHog + Sentry

### Key Features
- Zero Recommendations Gate — keeps improving until AI has zero suggestions
- Visual TDD loop — screenshot at 6 breakpoints → AI critique → fix → verify
- All 14 SKILL.md files under 500 lines (best practice compliant)
- 2,172 tokens/prompt overhead (48% optimized from baseline)
- Parallel agent spawning with worktree isolation
- Brian Decision Model predicting technology choices
- Voice of the Customer data with exact language patterns

### Hard Gates (nothing ships without)
- Playwright E2E: 0 failures at 6 breakpoints
- GPT-4o Vision: >= 8/10, zero layout breaks
- Lighthouse Accessibility: >= 95
- axe-core: 0 violations
- Yoast SEO: GREEN on all checks
- Flesch Reading Ease: >= 60