### PR TITLE
fix: add missing YAML frontmatter to ship reference docs

### DIFF
--- a/ship/commands/ship-ci-review-loop.md
+++ b/ship/commands/ship-ci-review-loop.md
@@ -1,3 +1,8 @@
+---
+description: "Reference: CI & Review Monitor Loop (Phase 4) for /ship — monitor loop algorithm, PR feedback handling, and comment resolution. Not a standalone command."
+allowed-tools: []
+---
+
 <ci-review-loop>
 # Phase 4: CI & Review Monitor Loop - Reference
 

--- a/ship/commands/ship-deployment.md
+++ b/ship/commands/ship-deployment.md
@@ -1,3 +1,8 @@
+---
+description: "Reference: Deploy & Validate phases (7-10) for /ship — platform-specific deployment monitoring and rollback. Not a standalone command."
+allowed-tools: []
+---
+
 # Phases 7-10: Deploy & Validate - Reference
 
 This file contains platform-specific deployment and validation for `/ship`.

--- a/ship/commands/ship-error-handling.md
+++ b/ship/commands/ship-error-handling.md
@@ -1,3 +1,8 @@
+---
+description: "Reference: Error Handling & Recovery procedures for /ship — failure modes, rollback steps, and resume instructions. Not a standalone command."
+allowed-tools: []
+---
+
 # Error Handling & Recovery - Reference
 
 This file contains error handling procedures for `/ship`.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three reference command files in the `ship/` plugin were missing YAML frontmatter entirely:

- `ship/commands/ship-deployment.md`
- `ship/commands/ship-ci-review-loop.md`
- `ship/commands/ship-error-handling.md`

Claude Code requires a YAML frontmatter block (with at minimum a `description` field) to register and describe command files. Without it, Claude Code may enumerate these files as commands but cannot describe them, and standalone invocation fails silently. The parent `ship.md` correctly references these as sub-documents, but the missing frontmatter creates ambiguity for the runtime.

## Fix

Added minimal YAML frontmatter to each file:

```yaml
---
description: "Reference: <purpose> for /ship — <detail>. Not a standalone command."
allowed-tools: []
---
```

The `allowed-tools: []` explicitly marks these as internal reference documents that don't need direct tool access (the parent `ship.md` declares the full tool budget). The descriptions clarify their role as sub-documents referenced by `/ship`.

## Impact

Without this fix, users who attempt to invoke these files directly (e.g., `/ship-deployment`) get no useful feedback. The frontmatter makes Claude Code's behavior deterministic for these files.