### PR TITLE
fix: add missing YAML frontmatter to audit-project reference docs

### DIFF
--- a/audit-project/commands/audit-project-agents.md
+++ b/audit-project/commands/audit-project-agents.md
@@ -1,3 +1,8 @@
+---
+description: "Reference: Multi-Agent Review (Phase 2) for /audit-project — agent coordination, finding consolidation, and framework-specific patterns. Not a standalone command."
+allowed-tools: []
+---
+
 # Phase 2: Multi-Agent Review - Reference
 
 This file contains detailed agent coordination for `/audit-project`.

--- a/audit-project/commands/audit-project-github.md
+++ b/audit-project/commands/audit-project-github.md
@@ -1,3 +1,8 @@
+---
+description: "Reference: GitHub Issue Creation (Phase 8) for /audit-project — creating issues for deferred findings and TECHNICAL_DEBT.md cleanup. Not a standalone command."
+allowed-tools: []
+---
+
 # Phase 8: GitHub Issue Creation - Reference
 
 This file contains GitHub integration for `/audit-project`.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two reference command files in the `audit-project/` plugin were missing YAML frontmatter entirely:

- `audit-project/commands/audit-project-agents.md`
- `audit-project/commands/audit-project-github.md`

Claude Code requires a YAML frontmatter block (with at minimum a `description` field) to register and describe command files. Without it, Claude Code may enumerate these files as commands but cannot describe them, and standalone invocation fails silently. The parent `audit-project.md` correctly references these as phase sub-documents, but the missing frontmatter creates ambiguity for the runtime.

## Fix

Added minimal YAML frontmatter to each file:

```yaml
---
description: "Reference: <purpose> for /audit-project — <detail>. Not a standalone command."
allowed-tools: []
---
```

The `allowed-tools: []` explicitly marks these as internal reference documents that don't need direct tool access (the parent `audit-project.md` declares the full tool budget including `Task`, `Bash`, `Read`, etc.). The descriptions clarify their role as phase sub-documents referenced by `/audit-project`.

## Impact

Without this fix, users who attempt to invoke these files directly get no useful feedback. With frontmatter, Claude Code can at minimum describe them and their relationship to the parent command.