### PR TITLE
fix: add missing allowed-tools to 5 commands that need tool access

### DIFF
--- a/bug-fix/commands/bug-fix.md
+++ b/bug-fix/commands/bug-fix.md
@@ -3,6 +3,7 @@ description: Streamlines bug fixing by creating a GitHub issue first, then a fea
 author: danielscholl
 author-url: https://github.com/danielscholl
 version: 1.0.0
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Write, Edit, Glob, Grep
 ---
 
 Understand the bug: $ARG

--- a/commit/commands/commit.md
+++ b/commit/commands/commit.md
@@ -3,6 +3,7 @@ description: Creates git commits using conventional commit format with appropria
 author: evmts
 author-url: https://github.com/evmts
 version: 1.0.0
+allowed-tools: Bash(git:*), Bash(npm:*), Bash(yarn:*), Bash(pnpm:*)
 ---
 
 # Commit Command

--- a/create-pr/commands/create-pr.md
+++ b/create-pr/commands/create-pr.md
@@ -3,6 +3,7 @@ description: Streamlines pull request creation by handling the entire workflow: 
 author: toyamarinyon
 author-url: https://github.com/toyamarinyon
 version: 1.0.0
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(biome:*), Read, Glob
 ---
 
 # Create Pull Request Command

--- a/documentation-generator/commands/documentation-generator.md
+++ b/documentation-generator/commands/documentation-generator.md
@@ -1,6 +1,7 @@
 ---
 description: Generate comprehensive documentation for code and APIs
 tags: [documentation, api-docs]
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 
 # Documentation Generator

--- a/pr-review/commands/pr-review.md
+++ b/pr-review/commands/pr-review.md
@@ -3,6 +3,7 @@ description: Reviews pull request changes to provide feedback, check for issues,
 author: arkavo-org
 author-url: https://github.com/arkavo-org
 version: 1.0.0
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Glob, Grep
 ---
 
 # Comprehensive PR Review Template


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Five commands declared no `allowed-tools` in their frontmatter. In Claude Code, a command with no `allowed-tools` cannot make any tool calls — all tool use is denied. This means each of these commands is broken: their described workflows silently fail at the first tool call.

| Command | Missing tools | Impact |
|---------|--------------|--------|
| `pr-review/commands/pr-review.md` | `Bash(git:*)`, `Bash(gh:*)`, `Read`, `Glob`, `Grep` | Cannot read diff or fetch PR data |
| `commit/commands/commit.md` | `Bash(git:*)`, `Bash(npm:*)`, `Bash(yarn:*)`, `Bash(pnpm:*)` | Cannot run pre-commit checks or execute git commit |
| `create-pr/commands/create-pr.md` | `Bash(git:*)`, `Bash(gh:*)`, `Bash(biome:*)`, `Read`, `Glob` | Cannot create branch, format files, or open PR |
| `documentation-generator/commands/documentation-generator.md` | `Read`, `Write`, `Edit`, `Glob`, `Grep` | Cannot read any source files to generate docs |
| `bug-fix/commands/bug-fix.md` | `Bash(git:*)`, `Bash(gh:*)`, `Read`, `Write`, `Edit`, `Glob`, `Grep` | Cannot create issue, checkout branch, commit, or push |

## Fix

Added `allowed-tools` to each command's frontmatter, scoped to the tools their body actually requires:

- **pr-review**: reads git history and gh PR data, searches code
- **commit**: runs package manager lint/build scripts and git operations
- **create-pr**: git branch/commit/push, biome format, gh PR creation, reads files
- **documentation-generator**: reads source files, writes/edits documentation output
- **bug-fix**: git checkout/commit/push, gh issue/PR creation, reads and edits code

The tool lists are minimal — each entry is justified by a concrete operation described in the command body.

## Impact

Without this fix, users invoking any of these commands get silent failures: the command body runs but all tool calls are rejected. With `allowed-tools` declared, the permissions contract is explicit and the commands can actually perform their described workflows.