### PR TITLE
fix: move security hook debug log from /tmp to ~/.claude/ and gate behind env var

### DIFF
--- a/security-guidance/hooks/security_reminder_hook.py
+++ b/security-guidance/hooks/security_reminder_hook.py
@@ -10,17 +10,21 @@ import random
 import sys
 from datetime import datetime
 
-# Debug log file
-DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"
+# Debug log file — gated behind env var to avoid writing by default
+_debug_log_enabled = os.environ.get("SECURITY_REMINDER_DEBUG", "0") == "1"
+DEBUG_LOG_FILE = os.path.expanduser("~/.claude/security-warnings-log.txt")
 
 
 def debug_log(message):
-    """Append debug message to log file with timestamp."""
+    """Append debug message to log file with timestamp (only when SECURITY_REMINDER_DEBUG=1)."""
+    if not _debug_log_enabled:
+        return
     try:
+        os.makedirs(os.path.dirname(DEBUG_LOG_FILE), exist_ok=True)
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         with open(DEBUG_LOG_FILE, "a") as f:
             f.write(f"[{timestamp}] {message}\n")
-    except Exception as e:
+    except Exception:
         # Silently ignore logging errors to avoid disrupting the hook
         pass
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium severity)

`security-guidance/hooks/security_reminder_hook.py` writes a debug log unconditionally to `/tmp/security-warnings-log.txt`:

```python
DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"
```

`/tmp` is world-writable on Linux/macOS. Any local user on the same machine can read this file. Since the log records which files are being edited and which security patterns triggered, it leaks session-scoped information — including file paths of files being written by Claude — to other local users.

The hook already uses `~/.claude/` for its session state files (e.g. `security_warnings_state_{session_id}.json`), making that the natural and already-trusted location.

## Fix

Two changes:

1. **Relocate the log file** from `/tmp/security-warnings-log.txt` to `~/.claude/security-warnings-log.txt`, which is user-private and already used for hook state.

2. **Gate writes behind `SECURITY_REMINDER_DEBUG=1`** so no log file is created by default. The log existed only for debugging; there's no reason to write it on every hook invocation in production.

```python
# Before
DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"

# After
_debug_log_enabled = os.environ.get("SECURITY_REMINDER_DEBUG", "0") == "1"
DEBUG_LOG_FILE = os.path.expanduser("~/.claude/security-warnings-log.txt")
```

Users who want debug logging can opt in with `SECURITY_REMINDER_DEBUG=1` in their environment.

## Impact

This is a minimal, backwards-compatible change. The hook's security warning behavior is unchanged. Debug logging is disabled by default (which was effectively true for any deployment that didn't know the undocumented `/tmp` path existed).