### PR TITLE
Add claude-ecom under new Business & Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [DevOps & Performance](#devops--performance)
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
+  - [Business & Analytics](#business--analytics)
   - [Companion & Personality](#companion--personality)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
@@ -151,6 +152,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+
+### Business & Analytics
+
+- [claude-ecom](https://github.com/takechanman1228/claude-ecom) - Ecommerce business-review plugin for D2C stores. Turns an order CSV into a structured monthly review with multi-horizon KPI decomposition (30d/90d/365d), ~30 automated health checks across revenue/customer/product, RFM cohorts, and a prioritized action plan with revenue impact estimates.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Hi — adding `claude-ecom`, an ecommerce business-review plugin for D2C stores.

**What it does**: Given an order CSV, it produces a structured monthly business review:
- Multi-horizon KPI decomposition (30d / 90d / 365d)
- ~30 automated health checks across revenue / customer / product
- RFM cohort segmentation (Champions / Loyal / At-Risk / Lost)
- Prioritized action plan with estimated revenue impact per finding

Hybrid architecture: Python handles deterministic KPI computation, Claude handles narrative and recommendations.

**Why a new section**: None of the existing categories (Integrations, Frontend & Design, Git, Code Quality, Backend, DevOps, Docs & Security, Developer Productivity, Companion) is an honest fit for a business-data / analytics plugin. I've added a new `Business & Analytics` section alongside `Image Generation` (which itself has one entry), but I'm happy to move it under an existing category if you'd prefer — e.g., Developer Productivity or DevOps & Performance (where `aws-cost-saver` is a cost/analytics-style precedent).

**Links**:
- Repo: https://github.com/takechanman1228/claude-ecom
- License: MIT
- Latest release: v0.1.3
- `marketplace.json` present for Claude Code plugin marketplace
- Active: yes, recent commits

Happy to revise wording, category, or placement.