### PR TITLE
Add vara-skills to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [vara-skills](https://github.com/gear-foundation/vara-skills) - 21 skills for shipping Rust smart contracts on Vara Network with the Gear/Sails framework. Full pipeline: spec → Sails impl → gtest → on-chain deploy via `vara-wallet`. Covers IDL codegen, React frontend, and event-driven indexer.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds [vara-skills](https://github.com/gear-foundation/vara-skills) to the Backend & Architecture section.

**What it is:** A plugin that installs 21 skills teaching Claude Code how to build and ship Rust smart contracts on Vara Network using the Gear/Sails framework. Covers the full pipeline: spec → architecture → Rust implementation → IDL/client codegen → deterministic gtest → React frontend → event-driven indexer → on-chain deploy via `vara-wallet`.

**Why Backend & Architecture:** Like `backend-architect` and `mcp-builder`, this plugin equips agents with architectural discipline for a specific backend domain — in this case, Actor-model message-passing smart contracts with typed IDL surfaces.

Install via `/plugin marketplace add https://github.com/gear-foundation/vara-skills` then `/plugin install vara-skills@vara-skills`. MIT licensed. Published by Gear Foundation.