### PR TITLE
Add git-timesheet to Git & Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [pr-review](./pr-review) - Comprehensive PR reviews with detailed feedback on code quality, security, and best practices.
 - [changelog-generator](./changelog-generator) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [ship](./ship) - Complete PR workflow from commit to production. Lint, test, review, and deploy.
+- [git-timesheet](https://github.com/MarcinSufa/git-timesheet) - Generates weekly PDF/CSV timesheets from git commit history. Realistic hour allocation by commit complexity, holidays for 9 countries, invoice totals (hours × rate), and push integrations with Toggl, Clockify, TMetric, and Harvest.
 
 ### Code Quality & Testing
 


### PR DESCRIPTION
Adds [git-timesheet](https://github.com/MarcinSufa/git-timesheet) to the **Git & Version Control** section.

### What it does

A Claude Code plugin that generates weekly PDF/CSV timesheets from your git commit history. `/timesheet` walks you through a date range, scans your repos, allocates hours per day based on commit complexity (lines + files), and outputs PDF/CSV plus an optional invoice summary.

### Features

- Realistic hour allocation (`score = lines + files × 10`) — not evenly split
- 9 countries of public holidays with Easter/computus
- 6 built-in languages plus dynamic translation
- Custom PDF templates from sample files (PDF/PNG/JPG/DOCX)
- Date range presets (first-half, second-half, last-month, custom)
- Invoice summary with `hours × hourly_rate`
- Push integrations: Toggl, Clockify, TMetric, Harvest
- Saved profiles, project mapping, multi-member support

### Install

```
/plugin marketplace add MarcinSufa/git-timesheet
/plugin install git-timesheet@marcin-sufa-plugins
```

MIT licensed. Beta v1.0.4-beta.