### PR TITLE
Add Voidly — 83+ tool MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [Voidly](https://github.com/voidly-ai) — MCP server with 83+ tools for censorship intelligence, encrypted agent messaging, and agent payments. Install: `npx @voidly/mcp-server`.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

Adds Voidly to the Integrations section — an MCP server installable via `npx @voidly/mcp-server` that extends Claude with 83+ tools.

## What it does

- **Censorship intelligence**: 19.6M live OONI measurements across 126 countries, 5,356 citable incidents, ML-powered risk forecasting, ISP/platform/election risk indexes.
- **Encrypted agent messaging**: E2E (Double Ratchet + X3DH + ML-KEM-768 PQ) agent-to-agent protocol for Claude Code / Cursor / Claude Desktop.
- **Agent payments**: Off-chain signed credit ledger for agent-to-agent transfers.

## Install

```bash
npx @voidly/mcp-server
```

Works in Claude Desktop, Claude Code, and Cursor.

## Source

- npm: https://www.npmjs.com/package/@voidly/mcp-server
- GitHub: https://github.com/voidly-ai

## Checklist

- [x] Addresses a real use case (real-time censorship/network intelligence + E2E encrypted agent messaging)
- [x] Doesn't duplicate existing functionality (no other MCP listed provides censorship data, and agent messaging is distinct from `connect-apps`)
- [x] Alphabetical placement within Integrations section