### PR TITLE
Add Emdash Skills to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [emdash-skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants. One-line prompts to deployed products on Cloudflare Workers.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [emdash-skills](https://github.com/megabytespace/claude-skills) to the Developer Productivity section.

**What it is:** A 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants. One-line prompts to deployed products on Cloudflare Workers.