### PR TITLE
Add magic-cc-codex-worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [magic-cc-codex-worker](https://github.com/wenqingyu/magic-cc-codex-worker) - Turns OpenAI Codex into a pool of parallel Claude Code agent workers with git worktree isolation, dual-model PR review, and resumable sessions via MCP protocol. Plugin bundles 9 slash commands + 3 subagents.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds [magic-cc-codex-worker](https://github.com/wenqingyu/magic-cc-codex-worker), a Claude Code plugin that turns OpenAI Codex into a pool of parallel agent workers running in isolated git worktrees.

## What it does
- Spawn N Codex agents in parallel, each in its own `git worktree` — no collisions on the main tree.
- Resumable sessions (continue a worker across Claude Code sessions via Codex `codex-reply` on stored `thread_id`).
- Dual-model PR review: mount a PR in a detached worktree, run a GPT reviewer alongside your Claude review.
- Role-tuned specialization (implementer / reviewer / planner / generic) with per-role sandbox + timeout.
- Auto-detected Magic Flow integration (Linear issue enrichment, branch conventions, workers.json mirror) — opt-out by absence.

## Stats
- 62 unit tests, strict TypeScript, CI on Node 20/22
- Self-contained single-file MCP server (no `npm install` needed at install time)
- 9 slash commands + 3 subagents + 9 custom MCP tools
- License: PolyForm Noncommercial 1.0.0 (free for independent devs / research / nonprofits; commercial use requires separate license)

Install via:
```
/plugin marketplace add wenqingyu/magic-cc-codex-worker
/plugin install magic-codex@magic-codex
```

Contribution checklist:
- [x] Real use case (parallel agent orchestration; dual-model review)
- [x] Does not duplicate an existing entry — nearest neighbor is `maestro-orchestrate` but this is Codex-specific, not Claude-subagent-based
- [x] Plugin is installed + tested (62 unit tests + live end-to-end verified)