### PR TITLE
Add artibot to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [artibot](https://github.com/Yoodaddy0311/artibot) - Cognitive orchestration OS for Claude Code with hierarchical 3-layer memory (working/episodic/semantic), GRPO-RLVR self-learning routing (linear/MLP/joint), MCP server, 29 agents, 100 skills, 56 commands, OTEL observability. ~6800 tests, MIT, zero external DB.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds **[artibot](https://github.com/Yoodaddy0311/artibot)** under *Backend & Architecture* (after `maestro-orchestrate`, same multi-agent orchestration category).

## What it is

Cognitive orchestration OS for Claude Code:

- Hierarchical **3-layer memory** (working/episodic/semantic, default-on)
- **GRPO-RLVR** self-learning routing — linear, MLP, joint (agent×skill) policies
- **MCP server** (stdio + skills/agents/memory/git bridges)
- **29 agents, 100 skills, 56 commands** with parallel agent teams
- **OTEL exporter** + multi-session dashboard
- **~6800 tests**, MIT license, **zero external DB**

## Why it fits

Multi-agent orchestration with parallel execution and persistent learning — same category as `maestro-orchestrate` and `agent-sdk-dev`. Differentiator is the self-learning routing layer (GRPO-RLVR) and hierarchical memory.

## Status

- v3.9-stable (released 2026-04-24)
- Submitted in parallel to anthropics/claude-plugins-official#1584