### PR TITLE
Add unslop to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - Claude Code plugin that removes AI writing patterns from text. Detects and rewrites ~15 characteristic tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary, performative balance, tidy essay shapes). Five intensity levels from subtle to anti-detector. Detection and rewriting are split — run lint-only passes on your own writing too. MIT licensed, no SaaS.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the **Developer Productivity** section.

**What it does:** Claude Code plugin that removes AI writing patterns from text. Detects and rewrites ~15 characteristic tells: tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary, performative balance, tidy essay shapes, and more.

**Key features:**
- Five intensity levels (subtle → balanced → full → voice-match → anti-detector)
- Detection and rewriting are split — run detection-only as a lint pass on your own writing
- Pattern-based approach (regex + heuristics), not detector-based — targets readable prose, not GPTZero scores
- MIT licensed, no SaaS, no auth, no rate limits

**Why Developer Productivity:** It's a Claude Code plugin that improves written output quality for developers who use AI to draft docs, READMEs, commit messages, or any prose.