### PR TITLE
Add prompt-to-asset to Image Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Image Generation
 
 - [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.
+- [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing requests across 30+ image generation models. Three execution modes: inline SVG, external prompt, or full API generation. Validates output for WCAG contrast and palette consistency. Zero API key required for first run via Pollinations and Stable Horde free tiers. MIT licensed.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Adds [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) to the **Image Generation** section.

**What it does:** MCP server that generates production-ready visual assets — app icons, favicons, OG images, logos, wordmarks — by routing each request across 30+ image generation models. Three execution modes: inline SVG, external prompt, or full API generation. Validates output for WCAG contrast and palette consistency. Zero API key required for the first run via Pollinations and Stable Horde free tiers.

**Why Image Generation:** The plugin's core purpose is image generation for developer assets. It sits alongside nano-banana as a complementary tool focused on production-ready assets (app icon → PNG, OG image → 1200×630 PNG) rather than general creative generation.

**Checklist:**
- [x] Entry follows existing format
- [x] MIT licensed, open source
- [x] Works with Claude Code as an MCP server and plugin
