### PR TITLE
Add weft to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [weft](https://github.com/dioptx/weft) - Deterministic workflow tracking with event-sourced state. Templates declare skill chains with bounded loops and per-step tool guards; PreToolUse/PreCompact/Stop hooks enforce the contract. State survives compaction via an append-only event log; `wf-rebuild` reconstructs state.json from events alone. Stdlib-only Python core, 191 tests, MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [dioptx/weft](https://github.com/dioptx/weft) under **Developer Productivity** — a Claude Code plugin that turns ad-hoc agent sessions into auditable, event-sourced workflows.

## What it does

Templates declare ordered steps with skill bindings (`/aot-plan`, `/staff-review`, `/fix-polish`), bounded loops (`loop_back_to`, `max_iterations`), and per-step tool guards. Four hooks (`SessionStart`, `PreToolUse`, `PreCompact`, `Stop`) enforce the contract — out-of-order tool calls are blocked, premature session exits are refused, and state survives compaction via a projection file.

## Why it's different

- **Event-sourced state** — every transition appended to `.claude/weft/events.jsonl`; delete the snapshot and `wf-rebuild` reconstructs from events alone.
- **Three template tiers** — project-local, user-global (`~/.weft/templates/`), and bundled. Same precedence applies for overrides.
- **No runtime deps** — Python stdlib only. 191 tests passing.

## Verify the claims

```
/plugin marketplace add dioptx/weft
/plugin install weft@dioptx-weft
/wf-start feature-workflow
```

Five reproducible asciinema-recorded GIFs in the README cover structural preview, first run, custom workflows, skill authoring, and event-log rebuild.

License: MIT.