### PR TITLE
Add KubeStellar Console to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [perf](./perf) - Performance analysis and optimization. Identify bottlenecks and improve speed.
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations. The `kc-agent` MCP server bridges Claude Code to kubeconfig and Kubernetes APIs for cluster management, policy enforcement, and CNCF project integrations across edge and cloud environments. ([Website](https://console.kubestellar.io))
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
 
 ### Documentation & Security


### PR DESCRIPTION
## What
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **DevOps & Performance** section.

## Why
KubeStellar Console is an open-source multi-cluster Kubernetes dashboard with AI-powered operations. Its `kc-agent` component is an MCP server that bridges Claude Code to kubeconfig and Kubernetes APIs — enabling cluster management, policy enforcement, and observability across edge and cloud environments directly from the coding agent.

- **GitHub**: https://github.com/kubestellar/console (CNCF project)
- **MCP server**: `kc-agent` — bridges browser/agents to kubeconfig + Kubernetes APIs
- **Website**: https://console.kubestellar.io
- **Features**: Multi-cluster management, real-time streaming, CNCF integrations (Argo, Kyverno, Istio, 20+ projects), supply chain security