### PR TITLE
feat: add solopilot — PM-driven autonomous engineering for solo builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [solopilot](./solopilot) - PM-driven autonomous engineering for solo builders. One command bootstraps spec-truth `PRD.md` + 3-agent (Coordinator/Implementor/Verifier) + drift detection + append-only learnings. Bundles `/autopilot`, `/cpp` (commit·push·PR), `/grill` (adversarial review), `/learn` (compound from PR).
 
 ### Companion & Personality
 

--- a/solopilot/.claude-plugin/marketplace.json
+++ b/solopilot/.claude-plugin/marketplace.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/hesreallyhim/claude-code-json-schema/main/schemas/marketplace.schema.json",
+  "name": "solopilot",
+  "description": "PM-driven autonomous engineering for solo builders.",
+  "version": "0.1.0",
+  "owner": {
+    "name": "flow"
+  },
+  "plugins": [
+    {
+      "name": "solopilot",
+      "source": "./",
+      "description": "PM-driven autonomous engineering for solo builders. Spec-truth, 3-agent (Coordinator/Implementor/Verifier), drift-resistant, self-improving. One command bootstraps the whole system.",
+      "version": "0.1.0",
+      "author": {
+        "name": "flow"
+      },
+      "homepage": "https://github.com/Mrbaeksang/solopilot",
+      "repository": "https://github.com/Mrbaeksang/solopilot",
+      "license": "MIT",
+      "category": "developer-tools",
+      "tags": [
+        "autonomous-agents",
+        "pm-driven",
+        "spec-driven",
+        "compound-engineering",
+        "agent-harness",
+        "solo-developer"
+      ],
+      "keywords": [
+        "claude-code",
+        "claude-code-plugin",
+        "autonomous-agents",
+        "pm-driven",
+        "spec-driven",
+        "compound-engineering"
+      ]
+    }
+  ]
+}

--- a/solopilot/.claude-plugin/plugin.json
+++ b/solopilot/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/hesreallyhim/claude-code-json-schema/main/schemas/plugin.schema.json",
+  "name": "solopilot",
+  "version": "0.1.0",
+  "description": "PM-driven autonomous engineering for solo builders. Spec-truth, 3-agent (Coordinator/Implementor/Verifier), drift-resistant, self-improving. One command bootstraps the whole system.",
+  "author": {
+    "name": "flow"
+  },
+  "homepage": "https://github.com/Mrbaeksang/solopilot",
+  "repository": "https://github.com/Mrbaeksang/solopilot",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "autonomous-agents",
+    "pm-driven",
+    "spec-driven",
+    "compound-engineering",
+    "agent-harness",
+    "solo-developer",
+    "drift-detection"
+  ]
+}

--- a/solopilot/.gitignore
+++ b/solopilot/.gitignore
@@ -1,0 +1,44 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Logs / temp
+*.log
+*.tmp
+.solopilot/grill/*.md
+
+# Secrets — never commit
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+credentials.json
+
+# Build artifacts
+dist/
+build/
+*.tsbuildinfo
+
+# Caches
+.npm/
+.cache/

--- a/solopilot/CHANGELOG.md
+++ b/solopilot/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to **solopilot** will be documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Planned for 0.2
+- Interactive PRD interview during `/autopilot` (replaces empty PRD template)
+- Pre-built routine bundles (`/autopilot --routines daily,weekly,on-pr`)
+
+## [0.1.0] - 2026-04-27
+
+Initial release. PM-driven autonomous engineering for solo builders.
+
+### Added
+- `/autopilot` — one-shot bootstrap of the full system: stack detection (11 manifest types), `CLAUDE.md` merge-only generator, `specs/PRD.md` template, 3-agent setup (Coordinator/Implementor/Verifier), `.claude/settings.json` with PostToolUse hooks, `LEARNINGS.md` append-only knowledge base, `/schedule` block printer.
+- `/cpp` — Conventional Commits message generator + commit + push + draft PR via `gh`. Refuses on secret patterns. Never `--amend`. Never `git add -A`.
+- `/grill` — staff-engineer adversarial review with 5 parallel passes (security / types / concurrency / edge cases / scope drift). Severity tags. Verdict: SHIP / FIX-FIRST / REWRITE.
+- `/learn` — extract patterns and anti-patterns from a PR or session, append to `LEARNINGS.md` (append-only) and the most generalizable to `CLAUDE.md`'s `## 학습` section.
+- `--autoloop` mode for `/autopilot` — self-paced PM cycle (verify → work → compound) with stop conditions.
+- Marketplace manifest for direct install via `/plugin marketplace add` and `/plugin install`.
+- MIT license.
+
+### Safety defaults
+- All file generators are merge-only or append-only — never overwrite user content.
+- `permissions.deny[]` includes `git push --force`, `git reset --hard`, `rm -rf /`, `npm publish`, `cargo publish`, `gem push`, `pypi upload`.
+- `--dangerously-skip-permissions` is never enabled.
+- `/schedule` is never invoked directly — copy-paste strings are printed instead.
+
+[Unreleased]: https://github.com/Mrbaeksang/solopilot/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Mrbaeksang/solopilot/releases/tag/v0.1.0

--- a/solopilot/LICENSE
+++ b/solopilot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 flow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/solopilot/README.md
+++ b/solopilot/README.md
@@ -1,0 +1,202 @@
+<div align="center">
+
+# 🛩️ solopilot
+
+**PM-driven autonomous engineering for solo builders.**
+
+One command. Full team. Coordinator + Implementor + Verifier work the spec, you sleep.
+
+[![Stars](https://img.shields.io/github/stars/Mrbaeksang/solopilot?style=flat-square&logo=github&color=yellow)](https://github.com/Mrbaeksang/solopilot/stargazers)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-orange?style=flat-square)](https://code.claude.com)
+[![Version](https://img.shields.io/badge/version-0.1.0-green?style=flat-square)](CHANGELOG.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](#contributing)
+
+[Install](#install) · [Quick start](#quick-start) · [Commands](#commands) · [How it works](#how-it-works) · [Why](#why-solopilot)
+
+</div>
+
+---
+
+> **TL;DR** — Run `/autopilot` in any repo. It detects your stack, writes `CLAUDE.md`, sets up a Coordinator (PM) / Implementor (engineer) / Verifier (QA) trio with `specs/PRD.md` as immutable truth, wires hooks for formatter/typecheck, drops in `/cpp` / `/grill` / `/learn` for the daily loop, and prints the exact `/schedule` strings to put it on autopilot. Compound engineering + context-driven development + agent harness, in one slash.
+
+---
+
+## Install
+
+```sh
+# 1. Add the marketplace
+/plugin marketplace add Mrbaeksang/solopilot
+
+# 2. Install the plugin
+/plugin install solopilot@solopilot
+```
+
+That's it. Four commands now available globally:
+
+| Command | Purpose |
+|---|---|
+| `/autopilot` | One-shot bootstrap of the full PM-driven system in any repo |
+| `/cpp`       | Commit · Push · PR — git diff → conventional commit → draft PR |
+| `/grill`     | Staff-engineer adversarial review of current branch |
+| `/learn`     | Extract patterns from a PR, append to `CLAUDE.md` + `LEARNINGS.md` |
+
+## Quick start
+
+```sh
+# Inside your project
+cd my-project
+/autopilot                    # interactive setup — answers go into specs/PRD.md
+/autopilot --autoloop         # setup + immediately start the PM cycle
+```
+
+Daily loop after setup:
+
+```sh
+/plan "<feature>"             # Coordinator drafts specs/plans/<feature>.md
+/work                         # Implementor picks next task, runs in worktree
+/grill                        # Adversarial review before merge
+/cpp                          # Commit · Push · draft PR
+/learn 123                    # Compound learnings from PR #123
+```
+
+## How it works
+
+**4 layers**, each maps to a real engineering team role:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Layer 0: specs/PRD.md is truth, immutable to agents     │
+├─────────────────────────────────────────────────────────┤
+│ Layer 1: Coordinator → Implementor → Verifier           │
+│          (PM)          (Engineer)     (QA)              │
+├─────────────────────────────────────────────────────────┤
+│ Layer 2: Quality gates — build → test → spec compliance │
+├─────────────────────────────────────────────────────────┤
+│ Layer 3: LEARNINGS.md (append-only) + CLAUDE.md "## 학습"│
+│          ↑ compound engineering — system gets smarter   │
+└─────────────────────────────────────────────────────────┘
+```
+
+`/autopilot` writes:
+
+```
+your-project/
+├── CLAUDE.md                 # auto-generated, merge-only
+├── LEARNINGS.md              # append-only knowledge base
+├── specs/
+│   └── PRD.md                # source of truth, agent read-only
+├── .claude/
+│   ├── agents/
+│   │   ├── coordinator.md
+│   │   ├── implementor.md
+│   │   └── verifier.md
+│   ├── commands/             # project-scoped /plan /work /verify /compound /drift
+│   └── settings.json         # PostToolUse hooks + permissions
+```
+
+Then prints `/schedule` strings for daily standup, weekly drift audit, and on-PR verification.
+
+## Why solopilot
+
+**The problem.** AI coding agents drift. They lose track of the spec, build past it, accumulate technical debt, and never learn from yesterday's mistakes. Solo developers feel this most — no PM, no QA, no review pressure.
+
+**The fix.** Treat the spec as truth. Split agent responsibilities so no single agent both decides and verifies. Make every PR teach the system something durable. Run it on schedule so the work continues while you sleep.
+
+solopilot codifies the patterns from:
+
+- **Compound Engineering** ([Every / Kieran Klaassen](https://every.to/guides/compound-engineering)) — the 4-step Plan→Work→Review→Compound loop
+- **Spec-Driven Development** — PRD as immutable truth, drift detection
+- **Agent Harness Engineering** — OODA loops, recovery ladders, quality gates ([ECC](https://github.com/affaan-m/everything-claude-code))
+- **Ralph Wiggum** ([Geoffrey Huntley](https://ghuntley.com/ralph/)) — fresh-context, codebase-as-memory loops
+- **Anthropic best practices** — Boris Cherny's plan-mode-first workflow, parallel sessions
+
+If you've used context-mode and felt the difference, you'll feel this.
+
+## Commands in detail
+
+<details>
+<summary><b>/autopilot</b> — bootstrap</summary>
+
+Detects your stack (`package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `Gemfile`, `composer.json`, `pubspec.yaml`, `build.gradle.kts`, `pom.xml`, `Makefile`), generates `CLAUDE.md` and `specs/PRD.md`, sets up the 3-agent system, configures PostToolUse hooks for formatter/typecheck, prints `/schedule` strings for routines.
+
+Idempotent — re-running merges, never overwrites your edits.
+
+```
+/autopilot                # full setup
+/autopilot --autoloop     # setup + start PM cycle loop
+/autopilot --update       # sync drift only
+/autopilot --dry-run      # preview without writing
+```
+</details>
+
+<details>
+<summary><b>/cpp</b> — commit · push · PR</summary>
+
+Analyzes uncommitted changes, classifies them (Conventional Commits), generates a message that explains *why* not *what*, commits with explicit file list (no `git add -A`), pushes (with upstream auto-detect), opens a draft PR via `gh`.
+
+```
+/cpp                      # auto
+/cpp --type feat          # force type
+/cpp "fix(auth): close timing leak"   # custom message
+```
+
+Refuses to commit if it sees a secret pattern. Never `--amend`. Never `git add -A`.
+</details>
+
+<details>
+<summary><b>/grill</b> — adversarial review</summary>
+
+5 parallel passes (security, types, concurrency, edge cases, scope drift) with severity tags (🔴/🟠/🟡/🟢). Optionally runs santa-method dual-review for convergence on top findings. Outputs to `.solopilot/grill/<run-id>.md` with verdict: SHIP / FIX-FIRST / REWRITE.
+
+```
+/grill                    # branch vs default base
+/grill --pr 123           # remote PR
+/grill --severity high    # filter
+/grill --quick            # single-pass
+```
+</details>
+
+<details>
+<summary><b>/learn</b> — compound from a PR</summary>
+
+Extracts 5 categories (patterns, anti-patterns, decisions, constraints, spec gaps) from a PR or current session, filters by quality (no duplicates, no triviality, must cite source), appends to `LEARNINGS.md` (append-only) and the most generalizable 1-3 to `CLAUDE.md`'s `## 학습` section.
+
+```
+/learn 123                # PR #123
+/learn session            # current conversation
+/learn 123 --pr-comment   # also post to PR
+```
+</details>
+
+## Prerequisites
+
+- [Claude Code](https://code.claude.com) installed
+- `gh` (GitHub CLI) authenticated, for `/cpp` and `/learn`
+- A project with `git init` already run
+
+Pairs well with: [`context-mode`](https://github.com/context-mode/context-mode), [`everything-claude-code`](https://github.com/affaan-m/everything-claude-code), [`compound-engineering-plugin`](https://github.com/EveryInc/compound-engineering-plugin).
+
+## Roadmap
+
+- [x] v0.1.0 — `/autopilot`, `/cpp`, `/grill`, `/learn`
+- [ ] v0.2 — interactive PRD interview during `/autopilot`
+- [ ] v0.3 — pre-built routines (`/autopilot --routines daily,weekly,on-pr`)
+- [ ] v0.4 — drift dashboard (`solopilot status`)
+- [ ] v0.5 — multi-repo coordinator mode
+
+## Contributing
+
+PRs welcome. Run `/grill --pr <your-pr>` before requesting review — meta-dogfooding.
+
+## License
+
+[MIT](LICENSE)
+
+---
+
+<div align="center">
+
+**If solopilot saved you a sprint, ⭐ the repo.**
+
+</div>

--- a/solopilot/commands/autopilot.md
+++ b/solopilot/commands/autopilot.md
@@ -1,0 +1,150 @@
+---
+description: One-shot bootstrap of PM-driven autonomous dev system — spec-truth, 3-agent (Coordinator/Implementor/Verifier), drift-resistant, self-improving. Sets up CLAUDE.md, agents, commands, hooks, and prints /schedule routine block.
+---
+
+# Autopilot
+
+Bootstrap a complete autonomous development system in the current project. **Idempotent** — re-running merges instead of overwriting.
+
+## Usage
+
+```
+/autopilot                  # full setup, prompt for missing info
+/autopilot --quiet          # skip confirmations, use detected defaults
+/autopilot --update         # only sync drift in existing setup
+/autopilot --routines-only  # only print /schedule strings
+/autopilot --no-routines    # skip step 10
+/autopilot --dry-run        # show plan, write nothing
+/autopilot --autoloop       # after setup, immediately invoke /loop on PM cycle
+```
+
+## What this command makes Claude do (in order)
+
+### 0. Preflight
+- Refuse if `pwd == $HOME`. Refuse if not a git repo (offer `git init`).
+- If files >50 lines exist at any target path, confirm before merging unless `--quiet`.
+
+### 1. Detect stack (use context-mode)
+**Required**: use `mcp__plugin_context-mode_context-mode__ctx_batch_execute` to read all manifests in one call — keeps raw file content out of the main context window.
+
+Commands to run in batch:
+- `cat package.json 2>/dev/null` (label: "package.json")
+- `cat go.mod 2>/dev/null` (label: "go.mod")
+- `cat Cargo.toml 2>/dev/null` (label: "Cargo.toml")
+- `cat pyproject.toml 2>/dev/null` (label: "pyproject.toml")
+- `cat requirements.txt 2>/dev/null` (label: "requirements.txt")
+- `cat Gemfile 2>/dev/null` (label: "Gemfile")
+- `cat composer.json 2>/dev/null` (label: "composer.json")
+- `cat pubspec.yaml 2>/dev/null` (label: "pubspec.yaml")
+- `cat build.gradle.kts 2>/dev/null` (label: "gradle")
+- `cat pom.xml 2>/dev/null` (label: "pom.xml")
+- `cat Makefile 2>/dev/null` (label: "Makefile")
+- `ls -la` (label: "tree")
+
+Then `ctx_search` for specific fields (scripts, packageManager, deps). Extract:
+- Language, package manager, build cmd, test cmd, lint cmd, format cmd, typecheck cmd
+- If ambiguous, ask once with detected options as multiple-choice.
+
+### 2. Detect git state
+Current branch, remote URL (note: routines need GitHub remote), default branch.
+
+### 3. Generate or merge `CLAUDE.md` (≤120 lines)
+If exists: preserve user content, only add missing sections. Sections:
+- `## Stack` — one-liner each (auto-detected)
+- `## Commands` — exact strings for build/test/lint/format/typecheck
+- `## Workflow` — Plan → Work → Verify → Compound. State: **`specs/PRD.md` is source of truth, agents read-only.**
+- `## Rules` — append-only `LEARNINGS.md`; no `--no-verify`; tests decide reality; no scope creep beyond current spec; immutable PRD.
+- `## 학습` — empty section, populated by `/compound`.
+
+### 4. Generate `specs/PRD.md` template (if missing)
+Frontmatter:
+```yaml
+---
+immutable-to-agent: true
+created: <YYYY-MM-DD>
+last-human-edit: <YYYY-MM-DD>
+---
+```
+Sections: Goal, Non-goals, Constraints, Acceptance Criteria, Out-of-scope.
+
+### 5. Generate `.claude/agents/` (3 files)
+- `coordinator.md` — PM role. Reads PRD, decomposes into atomic tasks, assigns priority via dependency graph, writes plans to `specs/plans/<feature>.md`. **Never writes code.** Tools: Read, Grep, Glob, Write (only to `specs/plans/`).
+- `implementor.md` — Engineer role. Receives one task + context packet (PRD excerpt, CLAUDE.md, relevant files). Executes in worktree. Reports diff + test results. Tools: full read/write within worktree, Bash for build/test only.
+- `verifier.md` — QA role. Read-only. Runs tests, compares diff against PRD acceptance criteria, flags drift with severity (low/medium/high). On `high`: pause loop, surface to human. Tools: Read, Grep, Bash (test/lint only).
+
+### 6. Generate `.claude/commands/` (5 files, project-scoped)
+- `plan.md` — invokes `coordinator` agent on $ARGUMENTS, produces `specs/plans/<feature>.md`
+- `work.md` — invokes `implementor` agent on next unblocked task from current plan
+- `verify.md` — invokes `verifier` agent; on drift severity=high, exits non-zero
+- `compound.md` — extracts session learnings, appends to `LEARNINGS.md`, proposes CLAUDE.md updates as a diff for human approval
+- `drift.md` — full repo PRD-vs-code drift audit, opens PR with findings
+
+### 7. Generate or merge `.claude/settings.json`
+Merge with existing. Fields:
+- `hooks.PostToolUse[]`:
+  - On Write|Edit matching detected source files: run formatter (silent if not detected)
+  - On Write|Edit: run typechecker (silent if not detected)
+- `hooks.Stop[]`:
+  - Suggest `/compound` if session had >5 tool calls and no learnings appended (non-blocking)
+- `permissions.allow[]`: stack-specific safe whitelist — test, build, lint, format, typecheck, `git status`, `git diff`, `git log`, `git branch`, `git switch`
+- `permissions.deny[]`: `git push --force`, `git reset --hard`, `rm -rf /`, `npm publish`, `cargo publish`, `gem push`, `pypi upload`
+
+### 8. Generate `LEARNINGS.md` (root, if missing)
+```yaml
+---
+append-only: true
+created: <YYYY-MM-DD>
+---
+```
+Body: explanation that entries are append-only, format `## YYYY-MM-DD — <topic>` with bullet points.
+
+### 9. Generate `.claude/agents/CLAUDE.md` (subagent context packet)
+Brief shared context all 3 agents inherit: project name, stack, PRD path, LEARNINGS.md path, build/test commands.
+
+### 10. Print `/schedule` block (skip if `--no-routines` or no GitHub remote)
+Output exact copy-paste strings the user runs in next message:
+
+```
+/schedule daily standup at 9am — scan yesterday's commits in this repo, summarize progress vs specs/PRD.md acceptance criteria, flag blockers, post to GitHub issue or local file
+/schedule weekly drift audit Sunday 10pm — run /drift, if findings open a PR with the report
+/schedule on github pull_request opened — run /verify against specs/PRD.md, post comment with drift report
+```
+
+Note: routines run on Anthropic cloud (1h minimum interval), need GitHub repo connector.
+
+### 10b. (if `--autoloop`) Start the PM cycle loop
+Use the `loop` skill to immediately start the cycle. Self-paced — no fixed interval. Loop body:
+```
+1. /verify   → if drift severity=high, pause and surface to human
+2. /work     → next unblocked task from current plan
+3. (every 3rd iteration) /compound → append learnings
+```
+Stop conditions: PRD acceptance criteria all met, OR human interrupts, OR 3 consecutive failed `/verify` runs.
+Print: "PM loop started. Use /loop status to inspect, Ctrl+C to halt."
+
+### 11. Print summary (5 lines exact)
+```
+✓ stack: <detected>
+✓ files: N created, M merged
+✓ agents: coordinator, implementor, verifier
+✓ next: /plan "<your first feature>"
+✓ routines: paste the block above into next message
+```
+
+## Safety rules
+
+- **Never overwrite** user content in `CLAUDE.md`, `settings.json`, `PRD.md` — only merge/append.
+- **Never run `/schedule` directly** (conversational, account-scoped) — print strings, user pastes.
+- **Never enable** `--dangerously-skip-permissions` or remove safety hooks.
+- **Confirm before writing** if any target file has >50 lines of existing user content (unless `--quiet`).
+- **Skip routine step** if no GitHub remote (Anthropic routines need cloud connector).
+- **Append, don't edit** `LEARNINGS.md` — even on re-run.
+
+## Arguments
+
+$ARGUMENTS:
+- `--quiet` — no confirmations
+- `--update` — sync drift only, no new files
+- `--routines-only` — print `/schedule` strings only
+- `--no-routines` — skip step 10
+- `--dry-run` — show plan, write nothing

--- a/solopilot/commands/cpp.md
+++ b/solopilot/commands/cpp.md
@@ -1,0 +1,119 @@
+---
+description: Commit-Push-PR — analyze git diff, generate Conventional Commits message, commit, push, open draft PR. One shot, idempotent.
+---
+
+# /cpp — Commit · Push · PR
+
+Turn uncommitted changes into a draft PR in one step. Generates a Conventional Commits message from the diff, pushes the branch, opens a draft PR via `gh`.
+
+## Usage
+
+```
+/cpp                       # auto-detect type, draft PR
+/cpp --ready               # open as ready (not draft)
+/cpp --type feat           # force commit type
+/cpp --no-pr               # commit + push only
+/cpp --base main           # PR base branch (default: detect from gh)
+/cpp "<custom message>"    # use the provided message verbatim
+```
+
+## What this command makes Claude do
+
+### 0. Preflight
+- Refuse if not a git repo, or no uncommitted changes (staged or unstaged).
+- Refuse if on `main`/`master`/`develop` — instruct user to switch branches first.
+- Verify `gh auth status` (skip if `--no-pr`).
+
+### 1. Inspect changes (use context-mode)
+Use `mcp__plugin_context-mode_context-mode__ctx_batch_execute` to keep diff out of main context:
+- `git status --short` (label: "status")
+- `git diff --stat HEAD` (label: "stat")
+- `git diff HEAD` (label: "diff")
+- `git log --oneline -5` (label: "recent")
+- `gh pr list --head $(git branch --show-current) --json number,state` (label: "existing-pr")
+
+Then `ctx_search` to extract: changed file count, dominant subsystem, breaking changes, test changes, dependency bumps.
+
+### 2. Classify (Conventional Commits)
+Pick `type` based on diff signal (override if `--type` given):
+- `feat` — new functionality
+- `fix` — bug fix
+- `refactor` — no behavior change
+- `perf` — speed/memory improvement
+- `docs` — only docs/comments
+- `test` — only tests
+- `build` — build system/deps
+- `ci` — CI config
+- `chore` — tooling, no production code
+
+Optional `scope` from dominant directory (e.g., `feat(auth):`).
+
+### 3. Generate message
+Format:
+```
+<type>(<scope>): <imperative subject ≤72 chars>
+
+<body: WHY, not what — 2-4 sentences max>
+
+<footer: BREAKING CHANGE / Closes #N if relevant>
+```
+
+Rules:
+- Imperative mood (`add`, not `added`)
+- No trailing period in subject
+- Body explains motivation, not changed lines
+- No `Co-Authored-By` (user has attribution disabled per global rules)
+- If user passed `"<custom message>"` as $ARGUMENTS, use it verbatim, validate format
+
+### 4. Commit
+- Stage explicitly named files (no `git add -A` — avoids leaking secrets/big binaries)
+- `git commit -m "<message via heredoc>"` to preserve newlines
+- If pre-commit hook fails: read error, fix, re-stage, NEW commit (never `--amend`)
+
+### 5. Push
+- Detect upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{u}` 2>/dev/null
+- If no upstream: `git push -u origin <branch>`
+- Else: `git push`
+- Never `--force` unless user explicitly typed `--force` in args
+
+### 6. Open PR (skip if `--no-pr`)
+- Check existing PR for branch (from step 1) — if exists, just print URL and exit
+- Else `gh pr create --draft` (or `--ready` if flag) with:
+  - Title = commit subject
+  - Body = HEREDOC with:
+    ```
+    ## Summary
+    <2-3 bullets from commit body>
+
+    ## Test plan
+    - [ ] <inferred from diff: tests added/modified, manual verification needed>
+
+    🤖 Generated with /cpp
+    ```
+- Print PR URL on success
+
+### 7. Summary (3 lines exact)
+```
+✓ committed: <short-sha> <subject>
+✓ pushed:    <branch> → origin
+✓ pr:        <url>  (or "skipped")
+```
+
+## Safety
+
+- **Never** `git add -A` or `git add .` — explicit file list only.
+- **Never** `--amend` — always new commit on hook failure.
+- **Never** `--force` push unless user typed it.
+- **Never** include `.env`, credentials, lock files >5MB, or anything matching project `.gitignore` patterns.
+- **Refuse** to commit if `git diff` shows what looks like a secret (API key pattern, private key header).
+- **Confirm** before committing if changed files >20 (likely accidental scope).
+
+## Arguments
+
+$ARGUMENTS:
+- `--ready` — open PR as ready (default: draft)
+- `--type <t>` — force commit type
+- `--no-pr` — skip PR creation
+- `--base <branch>` — PR base (default: repo default)
+- `"<message>"` — use verbatim, skip auto-generation
+- `--force` — allow force push (rare, dangerous)

--- a/solopilot/commands/grill.md
+++ b/solopilot/commands/grill.md
@@ -1,0 +1,110 @@
+---
+description: Staff-engineer adversarial review of current branch — security, types, race conditions, edge cases, scope drift. Severity-tagged findings. No mercy.
+---
+
+# /grill — Staff Engineer Code Grilling
+
+Brutally review the current branch like a staff engineer who hates your guts. Not friendly suggestions — actual blockers. Designed to catch what `/code-review` misses by adopting an adversarial mindset.
+
+## Usage
+
+```
+/grill                 # review uncommitted + branch vs base
+/grill --base main     # diff against specific base
+/grill --staged        # only staged changes
+/grill --pr 123        # grill an existing PR (fetches diff via gh)
+/grill --severity high # only show high/critical findings
+/grill --quick         # skip deep analysis (no santa-method, no agent spawns)
+```
+
+## What this command makes Claude do
+
+### 0. Setup
+- Detect base branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, fallback `main`)
+- Generate run id: `<branch>-<short-sha>-<timestamp>`
+- Output dir: `.solopilot/grill/<run-id>.md`
+
+### 1. Gather diff (use context-mode)
+Use `ctx_batch_execute`:
+- `git diff <base>...HEAD` (label: "diff")
+- `git diff <base>...HEAD --stat` (label: "stat")
+- `git log <base>..HEAD --oneline` (label: "commits")
+- `git ls-files | head -50` (label: "tree")
+- (if `--pr <n>`) `gh pr diff <n>` overrides
+
+Search index for: imports, dependency changes, async patterns, error handlers, input validation surfaces.
+
+### 2. Run 5 adversarial passes (parallel where possible)
+
+Spawn subagents in parallel (use Agent tool with subagent_type matching language):
+- **Security pass** — secrets in diff, SSRF, injection, auth bypass, missing rate limit, unsafe crypto, OWASP Top 10. Use `security-reviewer` agent or `security-review` skill.
+- **Type pass** — `any` proliferation, missing null checks, type assertions, schema mismatches at boundaries (API ↔ DB ↔ UI). Language-specific reviewer agent (`typescript-reviewer`, `python-reviewer`, etc.).
+- **Concurrency pass** — race conditions, missing locks/atomics, double-fetch, async without `await`, shared mutable state, request idempotency. Flag iterations over mutating collections.
+- **Edge case pass** — empty inputs, null/undefined, boundary values (0, -1, MAX_INT), unicode, timezone, empty collections, large inputs, network failures, partial writes.
+- **Scope-drift pass** — read `specs/PRD.md` if exists, check diff against acceptance criteria. Flag changes outside current spec scope. Cross-reference `LEARNINGS.md` for past anti-patterns.
+
+(if not `--quick`) Then run **santa-method skill** for adversarial dual-review convergence on the top 3 findings.
+
+### 3. Score each finding
+
+Severity tags:
+- 🔴 **CRITICAL** — ship-blocker, security/data loss/correctness
+- 🟠 **HIGH** — should fix before merge
+- 🟡 **MEDIUM** — fix soon, not blocking
+- 🟢 **LOW** — nit / style / future cleanup
+- ℹ️ **INFO** — non-actionable observation
+
+Filter by `--severity` if given. Default shows all but INFO.
+
+### 4. Output report
+
+Write to `.solopilot/grill/<run-id>.md`:
+```markdown
+# Grill Report — <branch>
+**Base:** <base> · **HEAD:** <sha> · **Date:** <YYYY-MM-DD HH:MM>
+**Files:** N · **Findings:** X critical, Y high, Z medium
+
+## 🔴 CRITICAL
+### [path:line] <title>
+**What:** <observed>
+**Why it bites:** <concrete failure scenario>
+**Fix:** <minimal change>
+**Confidence:** high/medium/low
+
+## 🟠 HIGH
+...
+
+## Spec drift
+<list of diff hunks not covered by PRD acceptance criteria, or "no drift detected">
+
+## Past patterns hit
+<refs to LEARNINGS.md entries that this diff repeats or violates>
+```
+
+Print **only the headers + counts** to chat — full report stays in file. End with:
+```
+✓ report: .solopilot/grill/<run-id>.md
+✓ verdict: <SHIP / FIX-FIRST / REWRITE>
+```
+
+### 5. Verdict logic
+- Any 🔴 → `REWRITE` (don't merge, redesign)
+- ≥3 🟠 or 1 critical-confidence-high without 🔴 → `FIX-FIRST`
+- Else → `SHIP`
+
+## Adversarial mindset rules
+
+- **Don't be polite.** "Looks good" is banned. If nothing is wrong, list 5 things you would have changed.
+- **Concrete failure scenarios.** Not "could leak data" — "if attacker sends X, server returns Y, exposing Z".
+- **No false positives via assumption.** If you grep and find no caller, ask first; don't conclude unused.
+- **Reference past learnings.** If `LEARNINGS.md` already records this anti-pattern, cite the entry.
+- **Question the spec.** If diff implements PRD literally but the PRD itself looks dumb, flag it.
+
+## Arguments
+
+$ARGUMENTS:
+- `--base <branch>` — diff base (default: repo default)
+- `--staged` — only staged
+- `--pr <n>` — grill a remote PR
+- `--severity <level>` — filter (critical|high|medium|low|info)
+- `--quick` — skip santa-method + parallel agents (single-pass)

--- a/solopilot/commands/learn.md
+++ b/solopilot/commands/learn.md
@@ -1,0 +1,148 @@
+---
+description: Extract reusable patterns and anti-patterns from a PR (or session), append to CLAUDE.md "## 학습" and LEARNINGS.md. Compound-engineering core loop.
+---
+
+# /learn — Compound from a PR
+
+The 4th step of compound engineering: turn what just happened into durable system knowledge. Future sessions read these, get smarter automatically.
+
+## Usage
+
+```
+/learn 123                     # learn from PR #123
+/learn 123 --anti              # only extract anti-patterns
+/learn 123 --pattern           # only extract reusable patterns
+/learn session                 # learn from current session (no PR needed)
+/learn 123 --no-claude-md      # write LEARNINGS.md only, skip CLAUDE.md update
+/learn 123 --pr-comment        # also post extracted lessons as PR comment
+```
+
+## What this command makes Claude do
+
+### 0. Resolve source
+- If $ARGUMENTS is a number → `gh pr view <n> --json title,body,baseRefName,headRefName,additions,deletions,changedFiles,commits,comments,reviews` + `gh pr diff <n>`
+- If `session` → use current conversation transcript (last 50 turns)
+- Else error with usage
+
+### 1. Gather context (use context-mode)
+Use `ctx_batch_execute`:
+- `gh pr view <n> --json ...` (label: "pr-meta")
+- `gh pr diff <n>` (label: "pr-diff")
+- `gh pr view <n> --json comments,reviews` (label: "pr-discussion")
+- `cat CLAUDE.md 2>/dev/null` (label: "claude-md")
+- `cat LEARNINGS.md 2>/dev/null` (label: "learnings")
+- `cat specs/PRD.md 2>/dev/null` (label: "prd")
+
+Then `ctx_search` for: review concerns, fix iterations, scope changes, surprises.
+
+### 2. Extract (5 categories)
+
+For each, only emit if signal is real (not boilerplate):
+
+**Patterns (do this again):**
+- New abstractions worth reusing
+- Workflow tactics that worked (e.g., "feature flag for X migration class")
+- Tool/library choices validated by this PR
+
+**Anti-patterns (don't do this):**
+- Bug shapes that recurred
+- Naming/organization choices that confused review
+- Tests that didn't catch what they should have
+- Dependencies that bit us
+
+**Decisions (preserve rationale):**
+- Why we chose A over B (so we don't re-relitigate)
+- Trade-offs accepted (latency for simplicity, etc.)
+
+**Constraints (newly discovered):**
+- Limits of a service/library
+- Performance ceilings
+- Compatibility surprises
+
+**Spec gaps (PRD insufficient):**
+- Acceptance criteria the PRD missed
+- Edge cases the spec didn't define
+- (Triggers a `/drift` recommendation)
+
+### 3. Filter — quality bar
+
+Skip if:
+- Already in `LEARNINGS.md` (search before write)
+- Trivial / could be derived from reading the code
+- Speculative (not validated by this specific PR)
+- Project-level info that belongs in CLAUDE.md `## Stack`/`## Commands`, not learnings
+
+Aim for **3-7 high-signal entries max**. Less > more.
+
+### 4. Append to LEARNINGS.md (always)
+
+Format:
+```markdown
+## <YYYY-MM-DD> — PR #<n>: <pr-title>
+
+### Pattern: <short title>
+- **What:** <one sentence>
+- **Why:** <reason / mechanism>
+- **When to apply:** <conditions>
+- **Source:** PR #<n>, files: <comma list, max 3>
+
+### Anti-pattern: <short title>
+- **What we did:** <observed>
+- **Why it bit:** <concrete failure>
+- **Instead:** <preferred approach>
+- **Source:** PR #<n>, commit <sha>
+
+### Decision: <topic>
+- **Chose:** <option A>
+- **Over:** <option B>
+- **Reason:** <one sentence>
+- **Reversible?:** yes / no / expensive
+- **Source:** PR #<n>
+```
+
+Append-only — never edit prior entries. If a prior entry is wrong, add a new entry referencing and superseding it.
+
+### 5. Update CLAUDE.md `## 학습` section (skip if `--no-claude-md`)
+
+Only the **most generalizable 1-3 entries** make it here (CLAUDE.md is loaded every session — keep precious).
+
+Format:
+```markdown
+## 학습
+
+- <YYYY-MM-DD> [pattern] **<title>** — <one line>. See LEARNINGS.md.
+- <YYYY-MM-DD> [anti] **<title>** — <one line>. See LEARNINGS.md.
+```
+
+Show diff to user, ask confirm if CLAUDE.md `## 학습` already has >20 entries (overflow signal — propose archiving older ones).
+
+### 6. (if `--pr-comment`) post to PR
+
+```bash
+gh pr comment <n> --body "<HEREDOC: extracted lessons in markdown>"
+```
+
+### 7. Summary (4 lines)
+```
+✓ source: PR #<n> "<title>"
+✓ extracted: <P> patterns, <A> anti-patterns, <D> decisions
+✓ written: LEARNINGS.md (+<N> entries), CLAUDE.md (+<M> entries)
+✓ next: review changes, commit when satisfied
+```
+
+## Rules
+
+- **Append-only** to LEARNINGS.md — never modify existing entries.
+- **No speculation** — every entry must cite the specific PR/file/commit it came from.
+- **Quality > quantity** — 3 high-signal beats 15 trivial.
+- **Don't duplicate** — search first, link if related.
+- **Confirm before** writing if `## 학습` in CLAUDE.md exceeds 20 entries.
+
+## Arguments
+
+$ARGUMENTS:
+- `<n>` — PR number, or `session` for current conversation
+- `--anti` — anti-patterns only
+- `--pattern` — patterns only
+- `--no-claude-md` — skip CLAUDE.md update
+- `--pr-comment` — also post as PR comment


### PR DESCRIPTION
## What

Adds `solopilot` to the **Developer Productivity** section.

solopilot is a Claude Code plugin that bootstraps a complete autonomous engineering system in one command. It bundles four slash commands that map to a real engineering team's roles:

| Command | Role |
|---|---|
| `/autopilot` | One-shot bootstrap: stack detection, `CLAUDE.md`, `specs/PRD.md` as immutable truth, 3-agent setup (Coordinator/Implementor/Verifier), PostToolUse hooks, `LEARNINGS.md`, `/schedule` routine strings |
| `/cpp` | Commit · Push · PR — Conventional Commits + draft PR via `gh` |
| `/grill` | Staff-engineer adversarial review (security/types/concurrency/edge cases/scope drift) |
| `/learn` | Extract patterns from a PR, append to `LEARNINGS.md` + `CLAUDE.md "## 학습"` |

## Why

Solo developers don't have a PM, QA, or review pressure. Agents drift, accumulate technical debt, and never learn from yesterday's mistakes. solopilot codifies the patterns from compound engineering (Every), spec-driven development, and agent harness engineering (ECC) into a single installable plugin.

## Structure

```
solopilot/
├── .claude-plugin/
│   ├── plugin.json
│   └── marketplace.json
├── commands/
│   ├── autopilot.md
│   ├── cpp.md
│   ├── grill.md
│   └── learn.md
├── README.md
├── LICENSE (MIT)
├── CHANGELOG.md
└── .gitignore
```

## Links

- Source: https://github.com/Mrbaeksang/solopilot
- Release: https://github.com/Mrbaeksang/solopilot/releases/tag/v0.1.0
