### PR TITLE
Add buildkite-skills to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [buildkite-skills](https://github.com/buildkite/skills) - Official Buildkite skills for pipelines, agent runtime, CLI, API, migration, and preflight. Teaches AI coding agents to use Buildkite CI/CD correctly.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds an entry for [buildkite/skills](https://github.com/buildkite/skills), the official Buildkite skills repo for Claude Code, Cursor, and other AI coding agents.

Six SKILL.md files covering pipelines, agent runtime, the bk CLI, REST and GraphQL APIs, CI migration, and preflight validation. Install with \`npx skills add buildkite/skills\` or \`/plugin marketplace add buildkite/skills\` in Claude Code.

The plugin already ships a valid \`.claude-plugin/plugin.json\` and \`.claude-plugin/marketplace.json\` manifest. License is MIT.
