### PR TITLE
feat: add claude-webcache to Developer Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-webcache](https://github.com/theYahia/claude-webcache) - Persistent cross-session WebFetch cache for Claude Code. Auto-saves every WebFetch to local SQLite via PostToolUse hook — instant hits on repeat URLs across sessions. Unlimited TTL, no setup beyond install.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Adds [claude-webcache](https://github.com/theYahia/claude-webcache) to the **Developer Productivity** section.

- Persistent cross-session WebFetch cache for Claude Code
- Auto-saves every WebFetch to local SQLite via PostToolUse hook — instant hits on repeat URLs across sessions
- Unlimited TTL, no setup beyond install (`npm i -g @theyahia/claude-webcache`)

Entry added after `backlog` in the Developer Productivity section.