### PR TITLE
Add claude-forge to Developer Productivity (11 agents · 33 commands · 24 skills · 15 hooks · 4 MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
+- [claude-forge](https://github.com/sangrokjung/claude-forge) - A complete plugin extending Claude Code with 11 custom agents, 33 commands, 24 skills, 15 hooks (covering 21 lifecycle events), 9 rules, and 4 MCP servers (playwright, context7, jina-reader, chrome-devtools@0.23.0). Plugin manifest follows the official Claude Code plugin spec exactly. Install via `/plugin marketplace add sangrokjung/claude-forge` then `/plugin install claude-forge`. MIT.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.


### PR DESCRIPTION
Hi ComposioHQ team! Adding [claude-forge](https://github.com/sangrokjung/claude-forge) under **Developer Productivity**.

**Why Developer Productivity:** It's a multi-component plugin distribution — agents, commands, skills, hooks, rules, MCP — that fits the same shape as `CCHub`, `skill-bus`, `backlog`, etc. in your existing Developer Productivity section. Happy to relocate to **Backend & Architecture** or any category you prefer.

**Plugin spec compliance** (your README's `Plugin Structure` template, lines 187-200):
- ✅ `.claude-plugin/plugin.json` — [manifest](https://github.com/sangrokjung/claude-forge/blob/main/.claude-plugin/plugin.json)
- ✅ `.claude-plugin/marketplace.json` — [marketplace metadata](https://github.com/sangrokjung/claude-forge/blob/main/.claude-plugin/marketplace.json)
- ✅ `skills/` — 24 SKILL.md files
- ✅ `commands/` — 33 slash commands
- ✅ `agents/` — 11 agent definitions
- ✅ `hooks/` — 15 lifecycle hooks (21 events covered)

**Install:**
```
/plugin marketplace add sangrokjung/claude-forge
/plugin install claude-forge
```

**Vetting:**
- Submitted to [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) (in review)
- 4-way independent skeptical review completed 2026-04-23 (super-research / security / architect / codex)
- Active maintenance: weekly releases
- License: MIT

Note: I'm submitting as an external link (matching the `CCHub` / `claude-context-mode` style in this section) rather than mirroring the plugin folder. Happy to switch to a folder mirror per your `Plugin Structure` template if you'd prefer the in-repo convention.

— @sangrokjung
