### PR TITLE
Add cowork-tasks - kanban task manager for Claude Cowork built on Live Artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [cowork-tasks](https://github.com/sabbah13/cowork-tasks) - First kanban task manager for Claude Cowork. Auto-captures tasks from email, Slack, meetings, Linear, Jira and 20+ sources, then routes them to a local-first board built on Live Artifacts. 5 skills (`/open-board`, `/triage-now`, `/new-task`, `/coach-me`, `/setup`), 1 MCP server, 1 task-extractor agent, 12 connectors. Local-first, MIT. ([Live demo](https://cowork-tasks.vercel.app))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [cowork-tasks](https://github.com/sabbah13/cowork-tasks) under **Developer Productivity** - sits next to `backlog` (PR #129) as another task-management plugin, but kanban-shaped and auto-feeding from external sources rather than command-driven.

## What it does

First kanban task manager built on Anthropic's Live Artifacts (released April 21, 2026). Auto-captures tasks from email, Slack, meetings, Linear, Jira, and 20+ sources, then renders them on a local-first board.

Plugin shape:
- 5 skills: `/open-board`, `/triage-now`, `/new-task`, `/coach-me`, `/setup`, `/health`
- 1 MCP server
- 1 task-extractor agent
- 12 connectors with monitors

License: MIT. Live demo: https://cowork-tasks.vercel.app