### PR TITLE
Update kaggle-skill description to reflect v2.1.0 (hackathon + 66-tool MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
-- [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, hackathon writeup retrieval and grading, and badge collection. Bundles the official Kaggle MCP server (66 tools).
 
 ### Frontend & Design
 


### PR DESCRIPTION
kaggle-skill shipped v2.1.0 in early May with two notable additions worth surfacing in the catalog description:

- New hackathon module — writeup retrieval, overview/rubric extraction, role-aware grading bundles. Built around the documented endpoint order from a live MCP audit.
- Refreshed MCP coverage to all 66 tools on https://www.kaggle.com/mcp (was ~40 in earlier docs).

This PR is a one-line description update under Plugins → Integrations. No structural changes.

Repo: https://github.com/shepsci/kaggle-skill
Release: https://github.com/shepsci/kaggle-skill/releases/tag/v2.1.0