### PR TITLE
Add claude-team-toolkit under Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Integrations
 
+- [claude-team-toolkit](https://github.com/tuannv14/claude-team-toolkit) - Team-ready skill pack with 15 multi-account integrations for Rails + React Native team workflows. Bundles Trello, Azure DevOps (Services + self-hosted Server), Heroku, Sentry, Slack, Firebase, Shopify, PostgreSQL, RSpec, Rails-security, k6, Maestro, Fastlane, React Native, xlsx-testcases. INI profile system, audit logging, security-first defaults, ~74% token savings on multi-step sessions.
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 


### PR DESCRIPTION
## What

Adds [`claude-team-toolkit`](https://github.com/tuannv14/claude-team-toolkit) under **Integrations**.

## Why

A 15-skill bundle for Rails + React Native team workflows — covering service APIs (Trello, Azure DevOps Services + self-hosted Server, Heroku, Sentry, Slack, Firebase, Shopify, PostgreSQL), mobile (React Native, Maestro E2E, Fastlane), and test/QA (RSpec, Rails-security, k6, xlsx-testcases).

## Highlights

- **Multi-account profiles** modeled after AWS CLI INI — same pattern across all 15 skills, including Shopify multi-app on the same store
- **Audit logging** of every mutation (timestamp + service + profile + action) — never records credentials or values
- **Security-first defaults**: chmod 600 enforced, tokens masked as `****<last4>`, validate creds against live API before save, refuse to load world-readable files
- **Token-efficient**: 779 tokens always-loaded for all 15 skill descriptions; ~74% savings on typical 3-skill × 4-invocation sessions
- **CI gated**: branch protection, validate plugin.json + SKILL.md frontmatter, shellcheck, lib unit tests, credential leak scan

## Verified

- License: MIT
- 6 GitHub releases tagged (v0.1.0 → v0.8.1)
- Listed on [ClaudePluginHub](https://www.claudepluginhub.com/plugins/tuannv14-claude-team-toolkit)
- Branch protection enabled on `main`
- Community health files: SECURITY.md, CODE_OF_CONDUCT.md, CHANGELOG.md, MAINTAINERS.md, SUPPORT.md, dependabot, CODEOWNERS, issue + PR templates