### PR TITLE
feat: add CTX — cross-session memory plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [CTX](https://github.com/jaytoone/CTX) - Cross-session memory plugin for Claude Code. Injects G1 (git decision timeline), G2 (BM25 code/doc search), and CM (chat memory vault) before each prompt. <1ms, no LLM calls, fully local. Memory recall 0.88 vs 0.00 baseline (MAB N=50). Install: `/plugin install ctx@jaytoone`
+
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
-- [CTX](https://github.com/jaytoone/CTX) - Cross-session memory plugin for Claude Code. Injects G1 (git decision timeline), G2 (BM25 code/doc search), and CM (chat memory vault) before each prompt. <1ms, no LLM calls, fully local. Memory recall 0.88 vs 0.00 baseline (MAB N=50). Install: `/plugin install ctx@jaytoone`
+- [CTX](https://github.com/jaytoone/CTX) - Never lose context between Claude Code sessions — automatically injects your decision history, code search, and chat memory before every prompt. Memory recall 0.88 vs 0.00 (50-session eval, Wilson CI). `/plugin install ctx@jaytoone`
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 


### PR DESCRIPTION
## CTX — Cross-session Memory for Claude Code

Adds **CTX** to the Developer Productivity section.

**What it does:**
- Injects G1 (git decision timeline), G2 (BM25 code/doc search), and CM (chat memory vault) before each Claude Code prompt
- Memory recall: 0.88 [0.762, 0.944] vs 0.00 baseline (MAB N=50, Wilson CI)
- Real-world utility: 39.6% of injected items cited by Claude (10,000+ turns measured)
- <1ms, no LLM calls, fully local

**Install:**
```
/plugin install ctx@jaytoone
```
or
```bash
pip install ctx-retriever && ctx-install
```

**Links:** [GitHub](https://github.com/jaytoone/CTX) | [PyPI](https://pypi.org/project/ctx-retriever/) | [Dev.to writeup](https://dev.to/jaewon_jang_d63fddcf69ac2/ctx-i-gave-claude-code-a-memory-that-actually-works-45id)