### PR TITLE
Feat: Add cc-remote-approval plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [cc-remote-approval](https://github.com/Manta-Network/cc-remote-approval) - Approve Claude Code permissions and answer questions from Telegram when you're away from your screen. Hooks run in parallel with
+  native dialogs — first responder wins. Channel-agnostic, stdlib-only, zero dependencies. ([Intro](https://x.com/LifeClaw_AI/status/2046585254417461386))
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adds [cc-remote-approval](https://github.com/Manta-Network/cc-remote-approval) — a Claude Code plugin that forwards permission prompts, questions, and MCP forms to Telegram so you can keep the agent moving while away from your screen.

## Why it fits the list

- **Solves a real workflow gap** — Claude Code pauses constantly for approvals (Bash, Edit, AskUserQuestion, MCP forms). Without this, leaving your screen means the agent stalls.
- **Hook-based, non-intrusive** — runs in parallel with the native dialogs; first responder wins, the other side auto-syncs. Doesn't replace anything.
- **Zero dependencies** — Python stdlib only.
- **Channel-agnostic architecture** — Telegram today, Slack/Discord pluggable via a single `Channel` interface.

## Entry

Adding under the plugins section:

```markdown
- [cc-remote-approval](https://github.com/Manta-Network/cc-remote-approval) - Approve Claude Code permissions and answer questions from Telegram when you're away from your screen. Hooks run in parallel with
  native dialogs — first responder wins. Channel-agnostic, stdlib-only, zero dependencies. ([Intro](https://x.com/LifeClaw_AI/status/2046585254417461386))
```

## Checklist

- [x] Entry follows the existing format
- [x] Project is open source (MIT)
- [x] README + setup docs in repo
- [x] Tested (235 automated tests)
