### PR TITLE
Add SwarmOps to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [SwarmOps](https://github.com/h4ckm1n-dev/SwarmOps) - Hardened fork of ruflo/claude-flow for global `~/.claude` installs. 46× faster `memory_search`, semantic memory via mxbai-embed-large, AIDefence wired into hooks, 0 npm-audit highs. Discovers and routes to your installed `~/.claude/{agents,skills,commands,plugins}/` registry.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## What is SwarmOps

SwarmOps is a hardened, optimized fork of [ruflo / claude-flow](https://github.com/ruvnet/claude-flow) for global `~/.claude/` installs. It ships agents, skills, slash-commands, and MCP servers — the standard Claude Code plugin surface — and discovers + routes to your existing `~/.claude/{agents,skills,commands,plugins}/` registry on startup.

## Why Backend & Architecture

Sits next to [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) (line 130) — both are multi-agent orchestration systems for Claude Code. SwarmOps' angle is global-install correctness plus measurable performance and security wins.

## Three strongest concrete claims

1. **46× faster `memory_search`** (74.2 ms → 1.6 ms warm). In-process SQLite connection pool eliminates per-call DB open. Reproducible via `npm run bench:memory` in the repo.
2. **Real semantic memory** via local Ollama + `mxbai-embed-large` (1024-dim) replacing the bundled `all-MiniLM-L6-v2` (384-dim). +33% recall on paraphrased queries. `swarm_init({task, strategy: "specialized"})` auto-picks user-installed agents based on task semantics.
3. **AIDefence wired into hooks** (`UserPromptSubmit` + `PreToolUse:WebFetch`) which upstream ships but never invokes. Plus 14 npm-audit CVEs patched (0 highs remaining), tightened permission allowlist, file perms hardened to 0600.

## Submission compliance

- Entry placed in `Backend & Architecture` next to `maestro-orchestrate` (the closest existing entry by use case).
- One entry, one section.
- No edits to other sections, contribution guidelines, or unrelated content.
- Repo is **MIT licensed**, same as upstream and consistent with this list's plugins.
- Externally-hosted entry (same pattern as `maestro-orchestrate`, `aws-cost-saver`, `security-sweep`, `CCHub`, `backlog`, etc.).

Thank you for maintaining this list.