### PR TITLE
Add claude-persona under new Marketing & Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [DevOps & Performance](#devops--performance)
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
+  - [Marketing & Research](#marketing--research)
   - [Companion & Personality](#companion--personality)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
@@ -153,6 +154,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+
+### Marketing & Research
+
+- [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels and pressure-test product concepts before paying for fieldwork. `/persona generate` produces reusable panels with diverse demographics and Big Five traits; `/persona ask` runs open-ended customer interviews; `/persona concept-test` runs structured A/B/C comparisons. Each persona runs in its own `claude -p` subprocess (agent-separated, no shared context), and results land in an executive report with theme synthesis, cross-tabs, and verbatims. Inspired by Microsoft's [TinyTroupe](https://github.com/microsoft/TinyTroupe).
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What this adds

[claude-persona](https://github.com/takechanman1228/claude-persona) — a plugin that builds AI persona panels for customer research and runs concept tests with agent-separated simulation. Inspired by Microsoft's [TinyTroupe](https://github.com/microsoft/TinyTroupe).

### Features

- **`/persona generate`** — reusable persona panels with diverse demographics, Big Five traits, and segment balance
- **`/persona ask`** — open-ended customer interviews for motivations, barriers, and decision criteria
- **`/persona concept-test`** — structured A/B/C comparison of messages, offers, or features
- **Agent-separated simulation** — each persona runs in its own `claude -p` subprocess to avoid groupthink
- **Executive report** — theme synthesis, cross-tabs (segment × choice), charts, and verbatims
- **Four bundled demos** with pre-generated panels and full results (Gen Z skincare, premium chocolate, RTD soda, sneakers)

### Why a new category

Added a **Marketing & Research** section because this plugin serves marketers, PMs, and strategy teams rather than engineers — it doesn't fit existing categories like Developer Productivity, Code Quality, or DevOps. Leaving the section open lets similar customer-research / market-research plugins slot in later.

### Checklist

- [x] Public repo with working plugin
- [x] Plugin manifest at `.claude-plugin/plugin.json`, SKILL.md at `skills/persona/SKILL.md`
- [x] MIT licensed
- [x] Bundled demos with reproducible outputs
- [x] Installable via `/plugin marketplace add takechanman1228/claude-persona`