### PR TITLE
Add Artel — infrastructure plugin for multi-agent coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [artel](https://github.com/NicolasPrimeau/artel) - Infrastructure for AI teams. Shared semantic memory, tasks, messages, and session handoffs for multi-agent fleets. Any agent on your network joins via HTTP or MCP.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

- Adds [artel](https://github.com/NicolasPrimeau/artel) to the **Developer Productivity** section
- Artel is a Claude Code plugin + MCP server (29 tools) for AI agent coordination: shared semantic memory, tasks, messages, and session handoffs for multi-agent fleets
- Addresses a real use case (multi-agent coordination infrastructure) not covered by existing entries
- Installs via `claude /plugin marketplace add NicolasPrimeau/artel`

## Test plan

- [ ] Verify entry renders correctly in the README
- [ ] Confirm GitHub link resolves to https://github.com/NicolasPrimeau/artel
- [ ] Confirm placement is alphabetically/contextually appropriate within the Developer Productivity section

🤖 Generated with [Claude Code](https://claude.com/claude-code)