### PR TITLE
Add agency-os to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [agency-os](https://github.com/AutomateLab-tech/agency-os) - Run your work like an AI agency from a single Notion board. Turns a Notion Tasks database into a source-of-truth dispatch board with a Suggestion → Discussion → To-Do → In Progress → Done flow, subtasks, dependencies, recurring cadence, and batch agent execution.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **agency-os** to the Developer Productivity section.

**What it is:** A Claude Code plugin that turns a Notion Tasks database into a source-of-truth dispatch board for managing your work. Status flow `Suggestion → Discussion → To-Do → In Progress → Done`, full subtask hierarchy, dependency-aware batch execution, recurring cadence, and one-paste kickoff briefs that stay bounded as discussion logs grow.

**Why this list / this section:** Conceptually adjacent to `backlog` (persistent task management) and `developer-growth-analysis` (Notion/chat-driven productivity). agency-os is differentiated by being Notion-native and by emitting per-task kickoff briefs that include corpus-scoped guidance plus the latest discussion entry, which is what makes batch agent execution survive long-lived workstreams.

**Plugin structure:** Ships as a Claude Code plugin with `.claude-plugin/plugin.json` + `marketplace.json` and bundled skills under `.claude/skills/agency-os/`. Tested in production on automatelab.tech.

**Repo:** https://github.com/AutomateLab-tech/agency-os
**Launch post:** https://automatelab.tech/agency-os-launch/

Disclosure: I'm the maintainer of agency-os.