### PR TITLE
Add sub-agents-skills and claude-code-workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Cross-LLM sub-agent dispatch primitive. Set `run-agent: codex|claude|cursor-agent|gemini` in an agent's frontmatter and it runs on that CLI. Mix backends in one project. Agent Skills spec compliant.
+- [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) - End-to-end workflows that thread acceptance criteria from PRDs through UI specs, design docs, and test skeletons into vertical work plans, with quality gates before commit. Backend, frontend, fullstack. Includes reverse engineering for legacy code.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adding two open-source Claude Code plugins to the Developer Productivity section:

- **[sub-agents-skills](https://github.com/shinpr/sub-agents-skills)** — Cross-LLM sub-agent dispatch primitive. Run Codex, Claude Code, Cursor, or Gemini as sub-agents from a single workflow by setting `run-agent:` frontmatter. Agent Skills spec compliant.
- **[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)** — End-to-end workflows that thread acceptance criteria from PRDs through UI specs, design docs, and test skeletons into vertical work plans, with quality gates before commit. Includes reverse engineering for legacy code.

Both are MIT licensed and actively maintained.

## Checklist

- [x] Addresses a real use case
- [x] Doesn't duplicate existing functionality
- [x] Follows the template structure
- [x] Has been tested