### PR TITLE
Add pluginpool to Developer Productivity (10-plugin marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [pluginpool](https://github.com/mturac/pluginpool) - A Claude Code plugin marketplace with ten focused developer productivity plugins: commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge. Each plugin's core is a deterministic Python helper (stdlib only at runtime) wrapped as a slash command — 89 hermetic tests across the suite. Install via `/plugin marketplace add mturac/pluginpool`. MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) — a Claude Code plugin marketplace with **ten focused developer productivity plugins** — under *Developer Productivity*.

The 10 plugins:
1. **commit-narrator** — semantic commit message from staged diff
2. **pr-storyteller** — PR title + body + test plan from commits
3. **test-gap** — lines in diff lacking test coverage (Cobertura / lcov / coverage.json)
4. **deps-doctor** — multi-ecosystem dependency audit (npm, pip, cargo, go)
5. **env-lint** — `.env` vs `.env.example` key parity (never prints values)
6. **secret-guard** — pre-commit secret scanner (pattern + entropy, redacted)
7. **standup-gen** — daily standup notes from git activity across repos
8. **todo-harvest** — TODO/FIXME/HACK scan with git blame author + age
9. **flaky-detector** — per-test flakiness % from N runs
10. **changelog-forge** — conventional commits → CHANGELOG + semver bump

Each plugin's core is a deterministic Python helper (stdlib only at runtime — no `pip install`) wrapped as a Claude Code slash command. **89 hermetic tests across the suite, all green.** MIT.

Install all at once via marketplace: `/plugin marketplace add mturac/pluginpool` then `/plugin install <name>@pluginpool`. Or clone individual plugins.