### PR TITLE
Add memory-pack to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [memory-pack](https://github.com/nvwalj/claude-code-memory-pack) - Six battle-tested slash commands for daily Claude Code workflow: `/scope` (5-step planning before coding), `/review` (security → correctness → performance pass), `/explain-this`, `/postmortem`, `/upgrade-deps`, `/release-notes`. Hand-written, MIT licensed, installable in one command via `/plugin marketplace add nvwalj/claude-code-memory-pack`.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [`memory-pack`](https://github.com/nvwalj/claude-code-memory-pack) to the Developer Productivity section.

### What it does

Six hand-written slash commands for daily Claude Code workflow:
- `/scope` — refuses to start coding until the plan is concrete (5 sections, no skipping)
- `/review` — security → correctness → performance, in that order
- `/explain-this` — what + how + why + how-to-change-safely
- `/postmortem` — captures root cause as a reusable CLAUDE.md entry
- `/upgrade-deps` — staged dep bumps with gates between phases
- `/release-notes` — from git log, user-facing, not engineer-facing

### Installable in one command

```
/plugin marketplace add nvwalj/claude-code-memory-pack
/plugin install memory-pack@nvwalj-memory-pack
```

### Quality checklist

- [x] Addresses a real use case (the friction of empty/stale `CLAUDE.md` files and ad-hoc slash commands)
- [x] No duplicate functionality — the commands are opinionated and complementary to existing entries
- [x] Follows the standard plugin format (`.claude-plugin/plugin.json` + `commands/*.md`)
- [x] Tested via direct install from the marketplace

MIT licensed, hand-written (not LLM-generated boilerplate).