### PR TITLE
Add polis-protocol plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [polis-protocol](https://github.com/yehudalevy-collab/polis-protocol) - Markdown coordination protocol for multi-vendor agent teams. Signed capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution. Vendor-agnostic across Claude Code, Codex, Gemini CLI.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## Summary

Adds **polis-protocol** to **Community Skills → Individual Skills**.

## What it is

A markdown-only coordination protocol for multi-vendor agent teams:

- **Signed capability cards** per citizen
- **ε-greedy multi-armed bandit routing** that learns from settled-contract outcomes
- **Chavruta paired review** for high-stakes contracts
- **Self-amending constitution** via a ratifiable amendment process

Vendor-agnostic — works across Claude Code, Codex, Gemini CLI, and any markdown-capable agent. MIT licensed.

Worked example with 3 citizens, a leader-shift on a tag after a real lesson, and a ratified amendment: [examples/research-team/](https://github.com/yehudalevy-collab/polis-protocol/tree/main/examples/research-team)

Repo: https://github.com/yehudalevy-collab/polis-protocol
