### PR TITLE
Add Espresso plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
+- [espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin. Output compression, global rules, RTK hook, Caveman ultra, GitNexus auto-config. Detects existing setup, installs only what's missing. 70-85% fewer tokens.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.


### PR DESCRIPTION
Adds Espresso to Developer Productivity section.

Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus auto-config. Detection-first: installs only what's missing. Works on Claude Code and Codex.

Repo: https://github.com/mirkobozzetto/espresso
License: MIT