### PR TITLE
Add click-to-mcp to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
-- [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+|- [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+|- [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Click/typer CLI as an MCP server. Run `npx click-to-mcp` to generate full MCP servers from any CLI tool — no separate server code needed. Open source (MIT).
 
 ### Companion & Personality
 


### PR DESCRIPTION
Add [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the Developer Productivity section.

click-to-mcp auto-wraps any Click/typer CLI as an MCP server (Model Context Protocol). Run `npx click-to-mcp` to generate complete MCP servers from any CLI tool without writing server code.

- Works with any Click/typer CLI
- Generates JSON-RPC handlers with stdio transport
- No separate server code needed
- Open source (MIT)