### PR TITLE
Add HeadlessTracker — headless crypto portfolio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [HeadlessTracker](https://github.com/tamasPetki/HeadlessTracker) - Headless crypto portfolio MCP server. Track balances across Bybit, Binance, MetaMask, Solana, and Polymarket — no dashboard, AI renders on demand.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 
 ### Frontend & Design


### PR DESCRIPTION
## What is HeadlessTracker?

A headless MCP server for crypto portfolio tracking. No dashboard UI — AI hosts (Claude, etc.) render your portfolio data on demand.

**Integrations:** Bybit, Binance, MetaMask (Ethereum), Solana (on-chain), Polymarket (prediction markets)

**GitHub:** https://github.com/tamasPetki/HeadlessTracker

Added to the **Integrations** section as it connects Claude to multiple crypto platforms.