### PR TITLE
Add: retro-daily - daily retro dashboard plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [retro-daily](https://github.com/gyanesh-m/retro-daily) - `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap. Spawns a detached, sandboxed `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session. ([Demo](https://gyanesh-m.github.io/retro-daily/))
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session.

Installs as a single-plugin marketplace:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Where it goes

`### Developer Productivity` — alongside `developer-growth-analysis`, `backlog`, and `context-mode`, which target the same session/productivity surface.

## Why it fits

A hook-driven plugin: the SessionStart hook is the entry point, the dashboard + background scout flow from there.