### PR TITLE
Add dod-guard under Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [dod-guard](https://github.com/atoslins/dod-guard) - Enforce a Definition of Done as an executable barrier. Stops agents from declaring "done" with stubs, tautological tests, or unverified claims. 7 read-only adversarial subagents + 11 deterministic detectors + 5 lifecycle hooks with `stop_hook_active` loop prevention. Python, JS/TS, Go coverage.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [dod-guard](https://github.com/atoslins/dod-guard) under **Code Quality & Testing**.

## What it does

DoD-Guard enforces the Definition of Done as an executable barrier for Claude Code. It targets the specific failure mode where LLM-driven coding assistants declare tasks "done" while leaving stubs, tautological tests, unverified claims, or silent regressions.

| Layer | Count | What it stops |
|-------|-------|---------------|
| Deterministic detectors (bash + python, no LLM) | 11 | stubs, TODOs, empty functions (AST), suspicious returns, tautological tests, NotImpl markers |
| Lifecycle hooks | 5 | bad edits in real time; `Stop` refuses to release the turn while DoD is unmet, with `stop_hook_active` loop prevention; `--no-verify` rejected |
| Adversarial subagents (read-only) | 7 | completeness, test quality, e2e proof, regressions, hostile review, claim validation, final-judge aggregator |
| Slash commands | 8 | `/dod:init`, `/dod:verify`, `/dod:audit`, `/dod:report`, `/dod:stubs`, `/dod:tests`, `/dod:checklist`, `/dod:confess` |
| Skills | 4 | reframe orchestrator behavior in any project that has `.dod-guard.json` |

## Verification

- 94 test assertions across 4 suites pass.
- `shellcheck -x` clean on every shell script.
- `claude plugin validate` passes for both `plugin.json` and `marketplace.json`.
- GitHub Actions CI runs all of the above on every push and PR.
- Released as v0.1.0 with MIT license.

## Why "Code Quality & Testing"

It overlaps with `code-review` and `test-writer-fixer` in spirit but operates a tier deeper: rather than catching style issues or generating tests, it audits *completion claims* — the most common silent failure mode of LLM-driven workflows.

Repo: https://github.com/atoslins/dod-guard
Release: https://github.com/atoslins/dod-guard/releases/tag/v0.1.0