### PR TITLE
Add Bleu to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Bleu](https://github.com/Nirvaan05/Bleu-plugin) - Planning plugin for living blueprints. Turns an idea into a file-backed markdown wiki (vision, architecture, ADRs, action points) that survives /clear and hands off to GSD, Superpowers, or raw Claude Code.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [Bleu](https://github.com/Nirvaan05/Bleu-plugin) under **Developer Productivity**.

Bleu is a planning plugin for Claude Code. It turns an idea into a file-backed markdown wiki (vision, architecture, ADRs, action points) that survives /clear and hands off to GSD, Superpowers, or raw Claude Code.

- Open source, MIT licensed
- Published with a v1.0.0 release
- Single-line addition, follows the existing entry format (external repo link + ASCII hyphen + description)