### PR TITLE
Add evc-team-relay-mcp to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) - MCP server that gives Claude Code read/write access to an Obsidian vault via the Team Relay API. Create notes, search docs, and keep your knowledge base in sync from any MCP-compatible client. Available on PyPI (`uvx evc-team-relay-mcp`).
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds evc-team-relay-mcp (MCP server for Obsidian vault read/write via Team Relay API) to the Developer Productivity section alongside codebase-graph and backlog. Available on PyPI, works with Claude Code and any MCP-compatible client. GitHub: https://github.com/entire-vc/evc-team-relay-mcp