### PR TITLE
Add claude-tmux-notifier under Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-tmux-notifier](https://github.com/ddzero2c/claude-tmux-notifier) - macOS notifications for Claude Code. Pings on turn-stop / permission prompts, click switches tmux client to the originating pane.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adds [claude-tmux-notifier](https://github.com/ddzero2c/claude-tmux-notifier) to the Developer Productivity section.

## Why

macOS notifications for Claude Code that work well for tmux users:

- **Stop**: notifies "Done, waiting for input" when Claude finishes a turn.
- **Permission prompt**: notifies with the prompt message when Claude needs approval.
- **Auto-clear**: dismisses the notification on next interaction (UserPromptSubmit / PreToolUse / SessionEnd).
- **Click-to-focus**: clicking activates the originating terminal (auto-detected via \$__CFBundleIdentifier) and switches the tmux client back to the originating session+pane.

Plugin is installable via marketplace:
\`\`\`
/plugin marketplace add ddzero2c/claude-tmux-notifier
/plugin install claude-tmux-notifier@ddzero2c
\`\`\`

## Checklist

- [x] Addresses a real use case (notification flow for tmux users)
- [x] Doesn't duplicate existing entries — no current plugin in the list provides tmux-aware notifications
- [x] Follows the README entry style (name + dash + one-line description)
- [x] Tested — installed and verified live via the marketplace install above