### PR TITLE
Add Quill — dual-AI thinking partner (MCP + Claude Code plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [quill](https://github.com/YG3-ai/quill) - Two AIs in conversation — one does the work, one gives perspective. Four skills: `consult` (stuck/frustrated), `perspective` (exploring), `assumptions` (surface what the AI decided silently), `mosaic` (parallel work + mutual review for high-stakes decisions). Free on existing Claude Pro + ChatGPT Plus subscriptions — no API key needed. Research-tested: 4/4 wins on decisions-under-tension vs single AI. `pip install quill-mcp` · By [@YG3-ai](https://github.com/YG3-ai)
+
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.

--- a/quill/.claude-plugin/plugin.json
+++ b/quill/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "quill",
+  "description": "Two AIs in conversation — one does the work, the other gives perspective. Four thinking-partner skills: consult, perspective, assumptions, mosaic. Research-tested: 4/4 wins on decisions vs single AI.",
+  "version": "0.2.2",
+  "author": {
+    "name": "YG3",
+    "url": "https://yg3.ai"
+  },
+  "repository": "https://github.com/YG3-ai/quill",
+  "install": "pip install quill-mcp"
+}


### PR DESCRIPTION
## What is Quill?

Quill is an MCP server + Claude Code plugin that mediates dialogue between two coding AIs — one does the work, the other gives perspective. You see what they agree on, what they disagree on, and what one spotted that the other missed.

## Four skills

- **consult** — for stuck/frustrated moments. The second AI reframes what's actually going on.
- **perspective** — for exploring moments. The second AI layers in an angle the first hasn't taken.
- **assumptions** — surfaces the technical choices the AI has been making silently, translated into plain-language yes/no questions you can actually answer.
- **mosaic** — for high-stakes decisions. Two AIs work different parts of the question in parallel, then cross-review each other's output for contradictions.

## Why it's different

**Free on existing subscriptions.** If you have Claude Pro + ChatGPT Plus (or vice versa), you already have two AIs. Quill lets them talk to each other — no API key, no per-token cost.

**Research-tested.** 4/4 wins on decisions-under-tension tasks vs single AI, judged blind by a neutral third model (Gemini). Full methodology in the repo.

**Works everywhere MCP does.** Claude Code, Codex CLI, Cursor, Cline, Continue.

## Install

\\\ash
pip install quill-mcp
\\\

Claude Code plugin: \/plugin marketplace add YG3-ai/quill\ then \/plugin install quill@yg3\

Repo: https://github.com/YG3-ai/quill · License: MIT · Maintainer: YG3 (yg3.ai)