### PR TITLE
Add OrgX Claude Code Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
+- [OrgX Claude Code Plugin](https://github.com/useorgx/orgx-claude-code-plugin) - Connects Claude Code to OrgX MCP tools, runtime hooks, skill sync, agent dispatch, durable decisions, artifacts, workstreams, and proof receipts.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.


### PR DESCRIPTION
## Summary
- Add OrgX Claude Code Plugin to the Developer Productivity section.
- Repository: https://github.com/useorgx/orgx-claude-code-plugin

## Verification
- git diff --check

## Notes
- OrgX connects Claude Code to MCP tools, runtime hooks, skill sync, agent dispatch, durable decisions, artifacts, workstreams, and proof receipts.