### PR TITLE
Add ux: design intelligence plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [ux](https://github.com/Laith0003/ux-skill) - Design intelligence with 18 slash commands, 5 sub-agents, deterministic regex linter (no LLM), and 72 brand DESIGN.md specs (Apple, Stripe, Linear, Figma, Tesla). Anti-AI-slop. MIT.
 
 ### Git & Version Control
 


### PR DESCRIPTION
## What's being added

**Plugin name:** `ux`
**Repository:** https://github.com/Laith0003/ux-skill
**Live landing:** https://uxskill.laithjunaidy.com
**License:** MIT
**Section:** Frontend & Design

Added as an external plugin (full URL like `kaggle-skill` already in the list).

## Description

Design intelligence for Claude Code that produces frontend work which doesn't read as AI-generated.

- **18 slash commands** across Frame / Audit / Generate / Apply
- **5 specialized sub-agents** (frontend-engineer, motion-engineer, copy-writer, research-synthesizer, design-system-architect)
- **30+ Polaris-style reference files**
- **Deterministic regex linter** (`/ux-lint`) — no LLM, CI-friendly, 30 anti-pattern rules
- **72 brand DESIGN.md specs** — Apple, Stripe, Linear, Notion, Figma, Tesla, BMW, Ferrari, Coinbase, Airbnb, Shopify, Vercel, Supabase and 59 more
- **Mandatory 10-field discovery protocol** before any generation
- **SEO foundation** baked into every public-web output
- **Cross-stack** — React, Next.js, Vue, Blade, Astro, vanilla

## Install

```
/plugin marketplace add https://github.com/Laith0003/ux-skill.git
/plugin install ux@ux-skill
```

Also submitted to the official Anthropic marketplace ([PR #2010](https://github.com/anthropics/claude-plugins-official/pull/2010)).

## Why it fits

The Frontend & Design section already has `frontend-design`, `artifacts-builder`, `theme-factory`, `canvas-design`, `senior-frontend`, and `frontend-developer`. The `ux` plugin extends this category with a comprehensive UX intelligence layer — audit + generate + system + microcopy + motion + a11y + deterministic linting + 72 brand DESIGN.md specs as a built-in reference library.

## Test plan

1. Visit https://uxskill.laithjunaidy.com (the landing was generated by the plugin's own \`/ux-design\` command — dogfood proof)
2. \`gh repo clone Laith0003/ux-skill\` to inspect manifest, commands, sub-agents
3. The plugin is MIT-licensed, no telemetry, no API keys required, no network calls in the linter