### PR TITLE
Add Aegis

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Aegis](https://github.com/GanyuanRan/Aegis) - Baseline-first, evidence-driven method-pack plugin for AI coding agents.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds Aegis to Developer Productivity.

Aegis ships a Claude plugin surface and method-pack skills for baseline-first, evidence-driven AI coding workflows.

Resource: https://github.com/GanyuanRan/Aegis