### PR TITLE
Add: social-publishing plugin — SocialClaw multi-platform social media scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [social-publishing](./social-publishing) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw. One workspace API key for campaigns, media upload, schedule validation, and run analytics.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 
 ### Frontend & Design

--- a/social-publishing/.claude-plugin/plugin.json
+++ b/social-publishing/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "social-publishing",
+  "description": "Schedule and publish social media posts across 13 platforms via SocialClaw. Supports X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest through a single workspace API key.",
+  "author": {
+    "name": "ndesv21",
+    "url": "https://github.com/ndesv21"
+  }
+}

--- a/social-publishing/skills/social-publishing/SKILL.md
+++ b/social-publishing/skills/social-publishing/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: "social-publishing"
+description: "When the user wants to schedule or publish social media posts across multiple platforms using SocialClaw. Use when the user mentions 'schedule post', 'publish to X', 'LinkedIn post', 'social media automation', 'connect social accounts', or wants to send content to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, or Pinterest."
+license: MIT
+metadata:
+  version: 1.0.0
+  author: ndesv21
+  category: marketing
+---
+
+# Social Publishing (SocialClaw)
+
+You are a social media publishing agent. Your job is to help the user schedule and publish content across social platforms via [SocialClaw](https://getsocialclaw.com) — an agent-first social publishing API.
+
+## Runtime Requirements
+
+- `SC_API_KEY` — workspace API key from https://getsocialclaw.com/dashboard
+- Optional: `socialclaw` CLI (`npm install -g socialclaw@0.1.12`)
+
+## Setup
+
+```bash
+# Set workspace API key
+export SC_API_KEY="<workspace-key>"
+
+# Verify access
+curl -sS -H "Authorization: Bearer $SC_API_KEY" https://getsocialclaw.com/v1/keys/validate
+
+# Install CLI (optional but recommended)
+npm install -g socialclaw@0.1.12
+socialclaw login --api-key <workspace-key>
+```
+
+## Workflow
+
+### 1. List connected accounts
+```bash
+socialclaw accounts list --json
+```
+
+If no accounts are connected, direct the user to connect via the dashboard or CLI:
+```bash
+socialclaw accounts connect --provider x --open
+socialclaw accounts connect --provider linkedin --open
+```
+
+### 2. Upload media (if needed)
+```bash
+socialclaw assets upload --file ./image.png --json
+# Returns: { "asset_id": "..." }
+```
+
+### 3. Build a schedule file
+Create `schedule.json` with the posts to publish:
+
+```json
+{
+  "posts": [
+    {
+      "provider": "x",
+      "account_id": "<account-id>",
+      "text": "Post content here",
+      "scheduled_at": "2026-06-01T10:00:00Z"
+    },
+    {
+      "provider": "linkedin",
+      "account_id": "<account-id>",
+      "text": "LinkedIn version of the post",
+      "scheduled_at": "2026-06-01T10:00:00Z"
+    }
+  ]
+}
+```
+
+### 4. Validate before publishing
+```bash
+socialclaw validate -f schedule.json --json
+```
+
+### 5. Publish
+```bash
+socialclaw apply -f schedule.json --json
+# Returns: { "run_id": "..." }
+```
+
+### 6. Monitor
+```bash
+socialclaw status --run-id <run-id> --json
+socialclaw posts list --json
+```
+
+## Supported Providers
+
+| Provider | Key |
+|----------|-----|
+| X (Twitter) | `x` |
+| LinkedIn profile | `linkedin` |
+| LinkedIn page | `linkedin_page` |
+| Instagram Business | `instagram_business` |
+| Instagram standalone | `instagram` |
+| Facebook Page | `facebook` |
+| TikTok | `tiktok` |
+| YouTube | `youtube` |
+| Reddit | `reddit` |
+| WordPress | `wordpress` |
+| Discord | `discord` |
+| Telegram | `telegram` |
+| Pinterest | `pinterest` |
+
+## MUST DO
+
+- Always run `socialclaw validate` before `socialclaw apply`
+- Confirm with the user before publishing to live accounts
+- Use `--json` flag on all CLI calls for machine-readable output
+
+## MUST NOT DO
+
+- Never store `SC_API_KEY` in files committed to version control
+- Never publish without validating first
+- Never assume account IDs — always fetch them with `socialclaw accounts list`
+
+## Source
+
+- npm: `npm install -g socialclaw@0.1.12`
+- Dashboard: https://getsocialclaw.com/dashboard


### PR DESCRIPTION
Adds a `social-publishing` plugin to connect Claude Code to [SocialClaw](https://getsocialclaw.com) for agent-driven publishing across 13 social platforms.

## What it includes

- `.claude-plugin/plugin.json` — plugin metadata
- `skills/social-publishing/SKILL.md` — full publishing workflow with the SocialClaw CLI

## Platforms supported

X (Twitter), LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest

## What the plugin does

- Lists connected social accounts
- Uploads media assets (images, videos)
- Builds and validates a `schedule.json` before publishing
- Applies the schedule (returns `run_id`)
- Monitors publishing run status and delivery analytics

## Install

```bash
git clone https://github.com/composiohq/awesome-claude-plugins.git
cd awesome-claude-plugins
claude --plugin-dir ./social-publishing
```

Then set your workspace API key:
```bash
export SC_API_KEY="<workspace-key>"
```

- Dashboard: https://getsocialclaw.com/dashboard
- License: MIT