### PR TITLE
Add Runtype Skills to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [runtype-skills](https://github.com/runtypelabs/skills) - AI product development on Runtype's managed edge runtime — build, deploy, and operate agents, flows, tools, and surfaces with six specialized skills for SDK usage, admin, templates, personas, and more.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## Summary

Adds [Runtype Skills](https://github.com/runtypelabs/skills) to the **Backend & Architecture** section.

**Runtype Skills** is an MIT-licensed Claude Code plugin with six specialized skills for AI product development on Runtype's managed edge runtime:

| Skill | Purpose |
|-------|---------|
| `runtype` | Core SDK usage and platform operations |
| `runtype-admin` | Admin and management tasks |
| `runtype-build-product` | End-to-end product building |
| `runtype-persona` | Persona chat widget configuration |
| `runtype-sdk-marathon` | Deep SDK exploration |
| `runtype-templates` | Starter templates and scaffolding |

- **Repo:** https://github.com/runtypelabs/skills
- **License:** MIT
- **Publisher:** runtypelabs
- **Format:** Standard `.claude-plugin` with skills in `skills/<name>/SKILL.md`

## Checklist

- [x] Addresses a real use case (AI product development on managed runtime)
- [x] Doesn't duplicate existing functionality
- [x] External link follows existing README format for externally-hosted plugins
- [x] Plugin has been tested