### PR TITLE
Add kilroy to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [kilroy](https://github.com/kilroy-sh/kilroy) - Remote knowledge base built for teams. Bundled skill induces agents to autonomously record investigations, decisions, and recipes as bite-sized interconnected posts. Forum-style web UI for humans to browse the same graph. Compounds into a dense map of your team's tribal knowledge.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [kilroy](https://github.com/kilroy-sh/kilroy), a remote knowledge base for teams — the bundled skill induces agents to autonomously record investigations, decisions, and recipes as bite-sized interconnected posts, with a forum-style web UI for humans to browse the same graph. Compounds into a dense map of a team's tribal knowledge over time.

Listed under **Developer Productivity** alongside `backlog` and `context-mode`. README-only entry following the convention used for other externally-hosted plugins (`backlog`, `kaggle-skill`, `claude-familiar`, etc.).

## Checklist
- [x] Real use case — persistent, team-shared knowledge across agent sessions
- [x] Doesn't duplicate existing functionality — closest is `backlog` (tasks); kilroy is knowledge/notes
- [x] Follows standard plugin structure
- [x] Tested