### PR TITLE
Add AsOf to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Code Quality & Testing
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
+- [AsOf](https://github.com/amatayomosley-web/asof) - Temporal-awareness hooks that flag stale in-context data before it corrupts reasoning. Tracks file mtime drift between Reads, parses prompts for embedded dates, and compares pseudo-stable claims against the training cutoff. `pip install asoftime && asof install`.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.


### PR DESCRIPTION
Adds [AsOf](https://github.com/amatayomosley-web/asof) to the **Code Quality & Testing** section.

## What it is

A temporal-awareness skill for tool-using LLMs. It addresses a specific failure mode: the agent treats all in-context data as if captured "now," regardless of how stale it actually is. AsOf surfaces three categories of staleness:

1. **In-context file staleness** — files Read earlier whose mtime has moved since (peer edits, user edits in another tool)
2. **Dated content in user paste** — stock quotes, earnings, log entries with embedded timestamps
3. **Pseudo-stable factual claims** — "typical hotel cost," "current Python version," etc. — compared against the model's training cutoff

## Why it fits Code Quality & Testing

The category is about preventing wrong outputs. AsOf prevents a specific class of wrong output: reasoning grounded in data that's silently obsolete. A/B tests on Opus 4.7 and Sonnet 4.6 show categorical behavior change when the verdict block is present.

## Install

`pip install asoftime && asof install` (patches `~/.claude/settings.json` idempotently). MIT.