### PR TITLE
Add context-os to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [context-os](https://github.com/sravan27/context-os) - Static-analysis repo graph injected pre-prompt so Claude's first turn opens the right file instead of grepping, plus PreToolUse hooks that intercept whole-file `Read`s (and pure `cat`/`less` dumps via Bash) and return the file's outline so Claude reads only the needed slice. No embeddings, no server. Retrieval CI-gated (MRR 0.984 synthetic, beats BM25 across 3 unseen OSS repos). −40.9% tokens on a cold-cache `claude --print` A/B (N=36, p=5e-7; warm-session dollar savings smaller due to caching). Stdlib Python, MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adding [context-os](https://github.com/sravan27/context-os) under **Developer Productivity**.

**What it is:** a stdlib-Python Claude Code plugin (MIT) that gives Claude a static-analysis repo graph (symbols + line ranges + imports + git-hot files) injected pre-prompt, so the first turn opens the right file instead of grepping for it. Plus PreToolUse hooks (`smart_read`, `smart_bash`) that intercept whole-file `Read`s — and pure `cat`/`less` dumps via Bash — and hand Claude the file's structural outline so it reads only the slice it needs. Plus `/savings` Receipts that measure both sources causally from the transcript.

**Why distinct from existing entries:**
- vs `context-mode`: that processes large *tool outputs* in subprocesses to keep summaries in context; context-os attacks earlier — *which file Claude opens first* + *whether a whole-file dump enters context at all*.
- vs `codebase-graph`: that's an MCP server with tree-sitter + FalkorDB; context-os is a stdlib-only hook (no MCP server, no DB, no embeddings), trading some recall for zero-deps + ~50ms hook latency.

**Honest evidence (CI-gated, reproducible):**
- Retrieval quality: MRR 0.984 on synthetic Py/TS/Rust, beats BM25 in every language across 3 unseen OSS repos (axios / ripgrep / requests).
- `claude --print` A/B: −40.9% aggregate tokens (N=36, p=5e-7) — *cold-cache* one-shots; in a warm interactive session the dollar delta is smaller due to caching, so the durable win is fewer first-turn tool calls + later compaction.
- ~100 assertions in CI cover the hook pipeline including adversarial Bash-parser pass-throughs (pipes, redirects, chains, substitutions must never false-positive-block).
- Anyone can validate on their own Claude Code history (no API key): `python3 python/evals/runners/replay_history.py`.

The plugin passes the contributing checks: addresses a real use case (first-turn exploration + compounding context bloat), doesn't duplicate the existing entries (different mechanism), follows the plugin structure (`.claude-plugin/plugin.json`, `commands/`, etc.), tested (CI badge green).

Happy to adjust the description length or category if you'd prefer it elsewhere.