### PR TITLE
Add Wenlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
-- [Origin](https://github.com/7xuanlu/origin/tree/main/plugin) - Local-first Claude Code plugin and MCP server that carries decisions, handoffs, and project context across AI work sessions.
+- [Wenlan](https://github.com/7xuanlu/wenlan/tree/main/plugin) - Claude Code plugin for a local-first AI knowledge base and LLM wiki, with source-cited pages, capture, recall, handoff, and MCP access.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
+- [Origin](https://github.com/7xuanlu/origin/tree/main/plugin) - Local-first Claude Code plugin and MCP server that carries decisions, handoffs, and project context across AI work sessions.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.


### PR DESCRIPTION
Adds Wenlan to the Developer Productivity section, updating the existing submission from its pre-Wenlan name and repository.

Wenlan provides a Claude Code plugin for a local-first AI knowledge base and LLM wiki, with source-cited pages, capture, recall, handoff, distill, and MCP access.

Disclosure: I maintain Wenlan.
