### PR TITLE
Add Catalan Natural plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Catalan Natural](https://github.com/albertolive/claude-skills) - Writes and reviews correct, natural Catalan: fixes castellanismes, English calques (catalanglish), weak pronouns, punctuation, accents, and currency formatting. Install: `/plugin marketplace add albertolive/claude-skills`
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **Catalan Natural** to the Developer Productivity section.

A Claude Code plugin (skill) that writes and reviews correct, natural Catalan, fixing castellanismes (Spanish interference) and English calques (catalanglish), plus weak-pronoun errors, per/per a, diacritics, punctuation (« » quotes, currency formatting) and accents. Rules sourced from official references (IEC, Optimot, ésAdir, Softcatalà).

- Repo: https://github.com/albertolive/claude-skills (MIT)
- Install: `/plugin marketplace add albertolive/claude-skills` then `/plugin install catalan-natural@albertolive-skills`

Placed under Developer Productivity as the closest existing bucket. If you'd prefer a dedicated "Language & Writing" section, happy to move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)