### PR TITLE
Add Finance & Data section: yield-intelligence and moatmri skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [DevOps & Performance](#devops--performance)
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
+  - [Finance & Data](#finance--data)
   - [Companion & Personality](#companion--personality)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
@@ -153,6 +154,11 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+
+### Finance & Data
+
+- [yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill) - Passive income portfolio analysis with live Treasury rates, dividend ETFs, and REIT data. Includes free hosted MCP endpoint (`https://api.intuitek.ai/yield/mcp`) — no API key required.
+- [moatmri](https://github.com/thebrierfox/moatmri-skill) - AI disruption pressure analysis — 10-vector map showing where AI breaks a business model first, with 90-day counterstrike plan.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Two Claude Code skills for passive income analysis and business intelligence, both MIT-licensed and installable via Claude Code.

## yield-intelligence

Passive income portfolio analysis with live US Treasury rates, dividend ETFs, and REIT data. Includes a free hosted MCP endpoint — no API key or registration required.

- **Repo:** https://github.com/thebrierfox/yield-intelligence-skill
- **Free MCP endpoint:** `https://api.intuitek.ai/yield/mcp`
- **Example:** Ask Claude to compare yield opportunities across asset classes for a $500/month income target

## moatmri

AI disruption pressure analysis — 10-vector map showing where AI breaks a business model first, with 90-day counterstrike plan.

- **Repo:** https://github.com/thebrierfox/moatmri-skill
- **Example:** Pass any company description and get a structured breakdown of which revenue streams, roles, and workflows AI disrupts first

---
Built by W. Kyle Million / IntuiTek¹
