### PR TITLE
fix: prevent path traversal in safeReadFile and validate file references

### DIFF
--- a/audit-project/lib/collectors/codebase.js
+++ b/audit-project/lib/collectors/codebase.js
@@ -41,8 +41,9 @@ const SOURCE_EXTENSIONS = {
  * Safe file read
  */
 function safeReadFile(filePath, basePath) {
-  const fullPath = path.resolve(basePath, filePath);
   const resolvedBase = path.resolve(basePath);
+  const requestedPath = path.resolve(basePath, filePath);
+  const fullPath = fs.realpathSync(requestedPath);
   if (!fullPath.startsWith(resolvedBase)) {
     return null;
   }

--- a/audit-project/lib/collectors/documentation.js
+++ b/audit-project/lib/collectors/documentation.js
@@ -35,13 +35,15 @@ function isPathSafe(filePath, basePath) {
  * @returns {string|null} File contents or null
  */
 function safeReadFile(filePath, basePath) {
-  const fullPath = path.resolve(basePath, filePath);
-  if (!isPathSafe(filePath, basePath)) {
+  const resolvedBase = path.resolve(basePath);
+  const requestedPath = path.resolve(basePath, filePath);
+  const fullPath = fs.realpathSync(requestedPath);
+  if (!fullPath.startsWith(resolvedBase)) {
     return null;
   }
   try {
     return fs.readFileSync(fullPath, 'utf8');
-  } catch {
+  } catch (err) {
     return null;
   }
 }

--- a/audit-project/lib/enhance/projectmemory-analyzer.js
+++ b/audit-project/lib/enhance/projectmemory-analyzer.js
@@ -90,7 +90,8 @@ function validateFileReferences(content, projectPath) {
     }
 
     // Resolve path and validate it stays within project root (prevent path traversal)
-    const fullPath = path.resolve(projectPath, ref);
+    const requestedPath = path.resolve(projectPath, ref);
+    const fullPath = fs.realpathSync(requestedPath);
     if (fullPath.startsWith(resolvedProjectPath) && fs.existsSync(fullPath)) {
       valid.push(ref);
     } else {


### PR DESCRIPTION
The `safeReadFile` function in multiple modules resolves the file path but then validates the original input path, not the resolved path. This allows path traversal attacks via symlinks. Additionally, the `validateFileReferences` function in projectmemory-analyzer.js resolves paths without verifying the input does not contain traversal sequences. The fix resolves the path first, then validates the resolved path against the base path to ensure security.