### PR TITLE
Add claude-bridge plugin (Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [claude-bridge](https://github.com/Stigmavlc/claude-bridge) - Claude Code drives a browser itself for web tasks: your logged-in Chrome via the Claude in Chrome extension (paid plan) for account/dashboard work, or a bundled headless Chrome DevTools MCP / Playwright for public lookups. Autonomous, with prompt-injection hardening.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds claude-bridge to the Integrations section.

When a Claude Code task needs the web, Claude Code drives a browser itself instead of asking you to do it by hand. For account and dashboard work it uses your own logged-in Chrome through the Claude in Chrome extension (needs that extension plus a paid Claude plan); for public, no-login lookups it uses a bundled headless Chrome DevTools MCP or Playwright. It runs the navigate, read, act, observe loop autonomously and reports back in the terminal, with prompt-injection hardening and hard stops for irreversible actions.

Like connect-apps and kaggle-skill, it takes real actions in external systems rather than only generating text. It is a plugin (not a hosted service), MIT licensed and free.

Repo: https://github.com/Stigmavlc/claude-bridge