### PR TITLE
Add worktree-warden (Git & Version Control)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [pr-review](./pr-review) - Comprehensive PR reviews with detailed feedback on code quality, security, and best practices.
 - [changelog-generator](./changelog-generator) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [ship](./ship) - Complete PR workflow from commit to production. Lint, test, review, and deploy.
+- [worktree-warden](https://github.com/mesat/worktree-warden) - Lets multiple Claude Code sessions share one repo without clobbering each other. A PreToolUse hook redirects branch-switching commands (`git checkout`/`switch`, `gh pr checkout`) into git worktrees — but only when another live session is actually present, so there's zero overhead when you work solo.
 
 ### Code Quality & Testing
 


### PR DESCRIPTION
Adds [**worktree-warden**](https://github.com/mesat/worktree-warden) under **Git & Version Control**.

It lets multiple Claude Code sessions work in the same repo without stomping on each other's working tree: a `PreToolUse` hook detects branch-switching commands (`git checkout`/`switch`, `gh pr checkout`, optionally `reset --hard`/`rebase`) and redirects them into a dedicated git worktree — **but only when another live session is actually sharing the repo**, so there's zero overhead and no worktree clutter when you're working solo.

- Pure bash + jq, MIT licensed, works on macOS and Linux
- CI (Ubuntu + macOS) green; conservative classifier covered by 40 assertions
- Fails open on every error path (never blocks the user on a bad day)

Single, on-topic entry. Thanks for maintaining the list!