### PR TITLE
Add Quill Deep Analysis to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Quill Deep Analysis](https://github.com/quillmeetings/claude-plugins) - Turn months of meetings in Quill into a deeply researched report. Ask a big question and it reads across your whole Quill history, gathers evidence pro/con, brainstorms perspectives and follow-up questions, and writes a report you can drill into, with every claim linked back to the moment it was said. Requires the Quill MCP. *By [quillmeetings](https://github.com/quillmeetings)*
 
 ### Companion & Personality
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
-- [Quill Deep Analysis](https://github.com/quillmeetings/claude-plugins) - Turn months of meetings in Quill into a deeply researched report. Ask a big question and it reads across your whole Quill history, gathers evidence pro/con, brainstorms perspectives and follow-up questions, and writes a report you can drill into, with every claim linked back to the moment it was said. Requires the Quill MCP. *By [quillmeetings](https://github.com/quillmeetings)*
+- [Quill Deep Analysis](https://github.com/quillmeetings/claude-plugins) - Turn months of meetings stored with Quill on your local computer into a deeply researched report. Ask a big question and it reads across your whole Quill history, gathers evidence pro/con, brainstorms perspectives and follow-up questions, and writes a report you can drill into, with every claim linked back to the moment it was said. Requires the Quill MCP. *By [Quill Meetings](https://quillmeetings.com)*
 
 ### Companion & Personality
 


### PR DESCRIPTION
Submitting on behalf of [Quill Meetings](https://quillmeetings.com).

This adds **Quill Deep Analysis** to the **Developer Productivity** section. It's a Claude Code skill that turns months of meetings in Quill into a deeply researched, fully cited report: you ask a big question, it reads across your whole Quill history, gathers evidence pro/con, brainstorms perspectives and follow-up questions, and writes a report you can drill into — with every claim linked back to the moment it was said.

It requires the Quill Meetings with the local MCP server enabled. Quill is an AI meeting assistant that transcribes and labels speakers and contacts locally on your computer. This skill does not store or read data from a cloud server.

Source/repo: https://github.com/quillmeetings/claude-plugins

The entry is an external-repo bullet, consistent with the other third-party entries in that section, and is appended at the end (section entries aren't alphabetized).

🤖 Generated with [Claude Code](https://claude.com/claude-code), with manual review by @mpdaugherty