### PR TITLE
Add Diffmode Growth Tactics (growth-strategy pipeline plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Diffmode Growth Tactics](https://github.com/acogood/diffmode_free) - Runs a growth-strategy research pipeline from a product URL: a competitor read, a buyer jobs-to-be-done map, and 7-9 unconventional acquisition tactics built for a founder's constraints. Mines growth mechanisms from fresh case studies and fuses 2-3 per tactic; every stage is reviewer-gated. Free, Claude Code + Codex, Apache-2.0, no account/API key. ([Website](https://diffmode.app/free-plugin))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **Diffmode Growth Tactics** under *Developer Productivity* — a free Claude Code + Codex plugin that researches a founder's market and synthesizes acquisition tactics.

Point `/run-growth-tactics` at a product URL and it runs a multi-stage, reviewer-gated pipeline locally (~90 min):
- a **competitor read** — who you're up against and the channels each rival leans on,
- a **buyer jobs-to-be-done map**, and
- **7–9 unconventional acquisition tactics** calibrated to the founder's budget, stage, and team — each fuses 2–3 growth mechanisms mined fresh from public case studies.

**Install**
```
claude plugin marketplace add acogood/diffmode_free
claude plugin install diffmode-growth-tactics@diffmode-free
```
Also runs on OpenAI Codex off the same skill files. Apache-2.0, no account or API key; Perplexity-optional with built-in web-search fallback.

- Repo: https://github.com/acogood/diffmode_free

Per CONTRIBUTING: real use case ✓, no duplicate (no growth/marketing plugin currently listed) ✓, tested ✓. Added as an external-link entry, matching the format of other external entries in this section.