### PR TITLE
Add agentbox plugin to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [agentbox](https://github.com/madarco/agentbox) - Drive AgentBox from Claude Code on the host: create isolated sandboxes for coding agents, run them in parallel, queue background jobs, and push via the host relay. Boxes run on local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B).
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds the **agentbox** Claude Code plugin (https://github.com/madarco/agentbox, MIT) to **Backend & Architecture**.

The plugin (`.claude-plugin/plugin.json` with bundled skills) lets Claude Code drive AgentBox on the host: create isolated sandboxes for coding agents, run them in parallel, queue background jobs, and push via the host relay. Boxes run on local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B).

README-only entry linking to the external plugin repo, matching the existing external entries in this section (e.g. maestro-orchestrate). The plugin addresses a real use case (sandboxed parallel agents) and doesn't duplicate existing entries.