### PR TITLE
Add claude-limit-guard (usage-limit guard) to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [claude-limit-guard](https://github.com/funhunter7/claude-limit-guard) - Watches your Pro/Max usage limits (5-hour and 7-day) in the status line and, at a threshold you set, gracefully saves a handoff and resumes after the reset — it acts on the limit, not just displays it. Pure Node, reads native rate_limits from stdin, status line + hooks, localized to your OS.
 
 ### Documentation & Security
 


### PR DESCRIPTION
## What

Adds [**claude-limit-guard**](https://github.com/funhunter7/claude-limit-guard) to the **DevOps & Performance** list.

It watches your Claude Pro/Max subscription usage limits (the 5-hour and 7-day windows) in the status line, and — at a threshold you choose — the Stop hook gracefully saves a handoff to `RESUME.md` and offers to resume after the limit resets. So unlike usage *displays*, it **acts** on the limit to prevent losing work mid-task.

- Pure Node (>=18), no Python needed
- Reads Claude Code's native `rate_limits` from stdin (no per-keystroke network call); OAuth usage endpoint as fallback
- Localized to the OS (weekday/date, labels, messages); ASCII fallback for legacy Windows console
- MIT licensed, CI green (lint + tests on Node 18/20/22)

Not a duplicate of the existing cost-observability entry (Manifest tracks token/cost telemetry; this guards subscription *limits* and saves/resumes work).

## How to validate

1. In Claude Code: `/plugin marketplace add funhunter7/claude-limit-guard` then `/plugin install claude-limit-guard@claude-limit-guard`
2. The status line shows e.g. `Limit session: 45% -> 14:40 | Week Limit: 38% -> Wednesday 6/10/2026 09:00`
3. Set a low threshold via `/limit-guard-config` to see the guard save a handoff at the limit.

No telemetry; the only network call is to Anthropic's own usage endpoint (same source as `/usage`), only as a fallback.