### PR TITLE
Add the-perfect-orchestrator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) - One lead Claude Code session commands N autonomous workers in tmux — with adversarial verification of results. Pure bash + tmux, zero daemons; ships the `/orch` skill, installable via plugin marketplace.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) to the Backend & Architecture section, after maestro-orchestrate.

It's an installable Claude Code plugin (marketplace add + install) shipping the `/orch` skill: one lead Claude Code session spawns, briefs, monitors and adversarially verifies N autonomous workers in tmux panes. Pure bash + tmux, zero daemons, coordination via plain files. MIT.

Full disclosure: the project is new (v0.2.0, days old) and I'm the author. Tested — a recorded real fleet run with raw transcripts is in [docs/realrun-2026-06-06](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06).