### PR TITLE
feat: add agent-critter to Companion & Personality

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
+- [agent-critter](https://github.com/Jedeiah/agent-critter) - A desk pet companion for Claude Code that reacts to agent hooks in real-time. Cross-platform (macOS + Windows), lightweight Rust binary (~15MB), compatible with 1,700+ Petdex sprites. 🐾
 
 ### Image Generation
 


### PR DESCRIPTION
Add [agent-critter](https://github.com/Jedeiah/agent-critter) — a desk pet companion for Claude Code that reacts to agent hooks in real-time.

- Cross-platform (macOS + Windows)
- Lightweight Rust binary (~15MB)
- Compatible with 1,700+ Petdex sprites
- Open source & fully local