### PR TITLE
feat: add ProposalCraft to Developer Productivity — MCP server for freelance proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [ProposalCraft](https://github.com/jabbawocky/proposalcraft) - MCP server for freelancers and consultants. Paste a client brief → get a proposal drafted in your voice from past winning work. Analyzes briefs for budget signals, red flags, and scope risks before you commit. Free tier (5 drafts/month), no API key required. ([Website](https://jabbawocky.github.io/proposalcraft/))
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adds [ProposalCraft](https://github.com/jabbawocky/proposalcraft) to the Developer Productivity section.

## Why it fits

ProposalCraft is an MCP server that works directly with Claude Code. It helps freelancers and consultants win more work by drafting client proposals in their own voice from past winning proposals — with tools for brief analysis, scope risk detection, and budget signal extraction.

**Details:**
- 8 MCP tools: `analyze_brief`, `draft_proposal`, `save_proposal`, `list_proposals`, `usage_status`, and more
- Install via Claude Code: `claude mcp add proposalcraft npx -- -y github:jabbawocky/proposalcraft`
- Free tier: 5 `draft_proposal` calls/month · No API key needed
- TypeScript, MIT license, privacy-first (proposals stored locally)