### PR TITLE
docs: add xberg-io plugins to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [kreuzberg](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzberg) - Local document extraction. Text, tables, metadata, and images from 91+ formats (PDF, Office, images with OCR, HTML, email, archives, academic). MCP server exposes the full extraction surface to your agent.
+- [kreuzcrawl](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzcrawl) - Web crawling and scraping with HTML→Markdown conversion and headless-Chrome fallback. MCP server exposes scrape, crawl, map, and interact tools.
+- [kreuzberg-cloud](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzberg-cloud) - Managed extraction via api.kreuzberg.dev. Skills cover REST API flows (extract, jobs, presigned uploads, usage); MCP server arrives in v0.2.0.
 
 ### Frontend & Design
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
-- [kreuzberg](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzberg) - Local document extraction. Text, tables, metadata, and images from 91+ formats (PDF, Office, images with OCR, HTML, email, archives, academic). MCP server exposes the full extraction surface to your agent.
-- [kreuzcrawl](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzcrawl) - Web crawling and scraping with HTML→Markdown conversion and headless-Chrome fallback. MCP server exposes scrape, crawl, map, and interact tools.
-- [kreuzberg-cloud](https://github.com/kreuzberg-dev/plugins/tree/main/plugins/kreuzberg-cloud) - Managed extraction via api.kreuzberg.dev. Skills cover REST API flows (extract, jobs, presigned uploads, usage); MCP server arrives in v0.2.0.
+- [xberg](https://github.com/xberg-io/plugins/tree/main/plugins/xberg) - Local document extraction. Text, tables, metadata, and images from 97+ formats (PDF, Office, images with OCR, HTML, email, archives). MCP server exposes the full extraction surface to your agent.
+- [crawlberg](https://github.com/xberg-io/plugins/tree/main/plugins/crawlberg) - Web crawling and scraping with HTML→Markdown conversion and headless-Chrome fallback. MCP server exposes scrape, crawl, map, and interact tools.
+- [html-to-markdown](https://github.com/xberg-io/plugins/tree/main/plugins/html-to-markdown) - Fast, lossless HTML→Markdown conversion with structured metadata, tables, and document-structure extraction.
+- [liter-llm](https://github.com/xberg-io/plugins/tree/main/plugins/liter-llm) - Universal LLM API client for 143 providers — chat, streaming, tools, embeddings, search, OCR, plus an OpenAI-compatible proxy and an MCP server.
+- [tree-sitter-language-pack](https://github.com/xberg-io/plugins/tree/main/plugins/tree-sitter-language-pack) - Code intelligence for 300+ languages via tree-sitter — structure, imports, symbols, and syntax-aware chunking.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds three plugins from the `kreuzberg-dev/plugins` marketplace under **Integrations**.

- **kreuzberg** — Local document extraction. Text, tables, metadata, images from 91+ formats with OCR. Backed by the `kreuzberg` Rust CLI (`brew install kreuzberg-dev/tap/kreuzberg`) which ships an MCP server out of the box.
- **kreuzcrawl** — Web crawling and HTML→Markdown conversion with headless-Chrome fallback. Backed by the `kreuzcrawl` Rust CLI with MCP server.
- **kreuzberg-cloud** — Managed extraction API. v0.1.0 documents the REST surface via skills; MCP server lands in v0.2.0 with the `kreuzberg-cloud` CLI binary.

All three are MIT-licensed and installable via the `kreuzberg-dev/plugins` marketplace (`/plugin marketplace add kreuzberg-dev/plugins`).

Repo: https://github.com/kreuzberg-dev/plugins
Maintainer: Kreuzberg, Inc. <support@kreuzberg.dev>