### PR TITLE
Add FluidDocs Deck Builder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [fluiddocs-deck-builder](https://github.com/FluidForm-ai/fluiddocs-deck-builder) - Builds single-file, type-correct HTML decks (pitch, sales, launch, keynote, all-hands) from a one-line brief, with PDF/PPTX import and inline editing. MIT.
 
 ### Git & Version Control
 


### PR DESCRIPTION
Real, tested plugin, not a duplicate of an existing entry. MIT, runs locally, output is one portable HTML file. Links to the external repo per the list's pattern. Placed under Frontend & Design since the output is visual deck design.