### PR TITLE
Add forge — Laravel Forge plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [forge](https://github.com/webmavens/claude-forge) - Drive Laravel Forge from Claude Code: deploy sites, manage servers, databases, SSL, daemons, scheduled jobs, and env files — every mutating action is gated behind a confirm-first dry-run.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds **forge** to DevOps & Performance — drives [Laravel Forge](https://forge.laravel.com) from Claude Code (deployments, servers, sites, databases, SSL, daemons, scheduled jobs, env files).

Repo / marketplace: https://github.com/webmavens/claude-forge

**Fits the guidelines:**
- Real use case; no existing Laravel Forge plugin in the list.
- External link (like `kaggle-skill` / `AgentLint` / `maestro-orchestrate`) — no plugin code copied into this repo.
- Tested end-to-end against a live Forge account; ships CI (help, mutation-gate, manifest validation on py3.8 + 3.12) and an offline mock for reproducible testing.
- Install: `/plugin marketplace add webmavens/claude-forge` then `/plugin install forge@claude-forge`.

Standard-library Python only, no dependencies. Users bring their own scoped Forge API token (stored locally, chmod 600); every mutating action requires an explicit confirm after a dry-run.