### PR TITLE
Add Slime under Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [Slime](https://github.com/bitqs/slime) - Turn your real Claude Code session into a turn-based RPG — statusline HUD + PixiJS battle arena where goals are bosses, todos are minions, and tokens are your resource. Pure observer (zero session impact), zero dependencies. [Live demo](https://slime-arena-demo.shuangqu.workers.dev).
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.


### PR DESCRIPTION
Adds [Slime](https://github.com/bitqs/slime) — turns a real Claude Code session into a turn-based RPG: a statusline HUD + a PixiJS battle arena where goals are bosses, todos are minions, and the token budget is your resource.

- Pure observer, driven by hooks — zero impact on the session, zero runtime dependencies, MIT
- XP/levels/badges/quests/loot/prestige, weekly shareable Wrapped card, en+zh
- Live demo (no install): https://slime-arena-demo.shuangqu.workers.dev
- Install: `/plugin marketplace add bitqs/slime` → `/plugin install slime@slime`

One bullet added under Developer Productivity, matching the existing format.