### PR TITLE
Add RegressionLedger to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [RegressionLedger](https://github.com/anlor1002-alt/regressionledger) - Stops your coding agent from re-applying fixes that already failed. Zero-dependency hook + CLI that fingerprints edits, links them to test/build outcomes, and blocks repeat failed fixes across sessions.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [RegressionLedger](https://github.com/anlor1002-alt/regressionledger) — a hook-based guardrail plugin that stops a coding agent from re-applying a fix that already failed.

It fingerprints each edit (normalized tokens), links it to the next test/build outcome, persists to a local ledger that survives session restarts and context compaction, and denies (PreToolUse) a repeat of a previously-failed fix with the reason attached.

- Real use case: the widely-reported "agent re-tries the same broken fix after context reset" loop; no existing entry covers cross-session outcome-linked blocking
- Tested: 35 tests, CI green on Node 18/20/22 × Linux/macOS/Windows
- Zero runtime dependencies, offline, MIT
- Installable as a plugin: `/plugin marketplace add anlor1002-alt/regressionledger` → `/plugin install regressionledger@anlor1002-plugins`

One-line README addition following the existing external-entry format; no other changes.