### PR TITLE
Add permafrost (DeepSeek prompt-cache aligning proxy plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [perf](./perf) - Performance analysis and optimization. Identify bottlenecks and improve speed.
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
+- [permafrost](https://github.com/jianzhichun/permafrost) - Cache-aligning proxy that freezes Claude Code's prompt prefix so DeepSeek's automatic context cache always hits. Measured 64% cost reduction on real Claude Code traffic; includes cold-anchor coalescing, idle keepalive, and live hit-rate diagnostics.
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))


### PR DESCRIPTION
Adds [permafrost](https://github.com/jianzhichun/permafrost) to **DevOps & Performance** as an external-link entry (same pattern as AgentLint / maestro-orchestrate).

**What it is:** a Claude Code plugin + zero-dependency passthrough proxy that freezes the prompt prefix (deterministic tool sort, env-block freezing, nonce stabilization, canonical serialization) so DeepSeek's automatic context cache keeps hitting when you run Claude Code against `api.deepseek.com/anthropic`. Ships `/permafrost:status|doctor|benchmark|wrap` commands, a SessionStart hook, and a savings statusline; installable via `/plugin marketplace add jianzhichun/permafrost`.

**Checklist:** real use case (DeepSeek users' cache hit rate); no duplicate in the list; standard plugin structure (`.claude-plugin/plugin.json`, commands/, hooks/), validated with `claude plugin validate --strict`; tested — unit + smoke suites in CI, plus live e2e against real Claude Code and the real DeepSeek API (66% hit / 64% cost cut, reproducible with `e2e/run_claude_code.sh`). MIT, fully local, no telemetry.