### PR TITLE
Add TokenKnows to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
+- [TokenKnows](https://github.com/johnnywuj81/tokenknows) - Distills the current Claude session into 7 structured document types — weekly reports, tech designs, ADRs, incident reviews, books, agent skills, and knowledge graphs — via an MCP server backed by a self-hosted 5-stage LLM pipeline. Works in Claude Code and Claude Cowork.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## What it does

[TokenKnows](https://github.com/johnnywuj81/tokenknows) is a Claude Code plugin that distills the current Claude session into 7 structured document types — weekly reports, tech designs, ADRs, incident reviews, books, agent skills, and knowledge graphs — through an MCP server backed by a self-hosted 5-stage LLM pipeline. It also works in Claude Cowork.

Install:

```
/plugin marketplace add johnnywuj81/tokenknows
/plugin install tokenknows@tokenknows
```

## Real use case

A long Claude Code debugging or design session contains decisions, trade-offs, and context that normally evaporate when the terminal closes. TokenKnows turns those sessions into artifacts the team actually consumes: the week's sessions become a team weekly report, an architecture discussion becomes an ADR or tech design doc, and recurring entities across sessions are linked into a searchable knowledge graph.

## Checklist

- Addresses a real use case (session knowledge capture for teams)
- Doesn't duplicate existing functionality — documentation-generator documents code; TokenKnows documents sessions
- Tested in both Claude Code and Claude Cowork
- MIT-licensed, hosted in its own repo (added as an external link entry, matching kaggle-skill / security-sweep / CCHub style)

Repo: https://github.com/johnnywuj81/tokenknows

🤖 Generated with [Claude Code](https://claude.com/claude-code)