### PR TITLE
Add qa-my-app to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [qa-my-app](https://github.com/elwizard33/qa-my-app) - End-to-end QA testing plugin. Auto-discovers routes, drives every page in a real browser via Playwright MCP, runs parallel test-runner subagents, and files defects to GitHub/Jira/Azure DevOps.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [qa-my-app](https://github.com/elwizard33/qa-my-app) to the **Code Quality & Testing** section (external-repo entry, same style as AgentLint).

**qa-my-app** (`qa-catalog`) is an end-to-end QA testing plugin for Claude Code:

- statically discovers every user-facing route (Next.js, Vite + React Router, Angular, SvelteKit, Vue, Remix, Blazor, plain HTML)
- drives every page in a real browser via the bundled Playwright MCP
- generates a deep QA task catalog (validation matrices, modals, buttons, role gates)
- runs the platform in parallel test-runner subagents and verifies results against a schema
- files defects with screenshots to GitHub/Jira/Azure DevOps if connected

Install:
```
/plugin marketplace add elwizard33/qa-my-app
/plugin install qa-catalog@qa-my-app
```

MIT licensed. Docs: https://elwizard33.github.io/qa-my-app/