### PR TITLE
Add Headroom — native macOS Claude Code usage monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Headroom](https://github.com/patwalls/headroom) - Native macOS menu bar app monitoring Claude Code session (5h) and weekly (7d) usage limits as live percentages, color-coded before limits hit. Zero network calls, MIT license, signed & notarized.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Headroom is a free native macOS menu bar app that monitors Claude Code's session (5h) and weekly (7d) usage limits as a live percentage in the menu bar.

**Why Developer Productivity section:**
- Lives in the macOS menu bar — zero UI friction, always visible
- Color-coded: green → amber at 80% → red at 90%
- Shows session cost, active model, context window fill, reset countdowns
- Zero network calls — reads a local file written by Claude Code's own status line hook (no API keys, no polling)
- Native Swift, MIT license, signed & notarized, ~267 KB, macOS 13+

**Links:**
- GitHub: https://github.com/patwalls/headroom
- Site: https://headroom.walls.sh
- Brew: `brew install --cask patwalls/tap/headroom`