### PR TITLE
Add compounded — correction-learning plugin with a trust ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [compounded](https://github.com/ankitkr3/compounded) - Learns from your corrections — approved lessons become rules that earn autonomy through a trust ladder (verified → trusted → autonomous; one mistake = one level down). Active rules inject at session start. Python stdlib only, no daemon, 100% local.
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.


### PR DESCRIPTION
Adds **[compounded](https://github.com/ankitkr3/compounded)** under *Developer Productivity*.

**What it does:** learns from your corrections. When you correct Claude and it does corrective work, a Stop hook captures the lesson, Claude extracts the generalizable rule, and asks you to approve it before saving. Approved rules inject at every session start, and earn autonomy through a trust ladder — verified → trusted → autonomous, with one correction demoting one level.

**Per the contribution guidelines:**
- **Real use case:** stop re-explaining the same corrections every session ("when I ask for the latest model, web-search first").
- **No duplication:** memory plugins (claude-mem etc.) capture and recall; compounded adds the *governance* layer — approval-gated capture and earned/revocable autonomy. Different problem.
- **Quality:** 55 unit tests, CI on Linux/macOS across Python 3.9–3.12, Python stdlib only, no daemon, 100% local. MIT.

Install: `/plugin marketplace add ankitkr3/compounded-marketplace` → `/plugin install compounded@compounded-marketplace`