### PR TITLE
Add grounded (grounding-enforcement guardrail plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Code Quality & Testing
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
+- [grounded](https://github.com/hyde0395/grounded) - Deterministic guardrail that blocks ungrounded agent actions: editing files never read, installing hallucinated packages, citing dead URLs. Hooks + a local evidence ledger, no LLM in the judgment path.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.


### PR DESCRIPTION
Adds [grounded](https://github.com/hyde0395/grounded) to **Code Quality & Testing**.

grounded is a Claude Code plugin that deterministically blocks agent actions that lack evidence — editing files never read this session, installing packages that don't exist on npm/PyPI/crates.io (19.7% of LLM-recommended packages don't exist per a USENIX Security 2025 study), and citing dead URLs. PostToolUse hooks accrue evidence into a local ledger; PreToolUse hooks demand it before acting. No LLM in the judgment path, Python stdlib only, MIT, 200+ offline tests, demo GIF of a real blocked session in the README.

Checklist per contributing guidelines: real use case (hallucinated installs / blind edits), no duplicate of existing entries (closest is lint/review tooling — grounded gates actions at runtime instead), tested (203-test suite + live plugin-mode verification).