### PR TITLE
Add codex-helper (Claude ↔ Codex orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [codex-helper](https://github.com/toniles/codex-helper-plugin) - Non-blocking Claude ↔ Codex orchestration: multi-turn review dialogues, aspect-based code reviews, and Codex implementation jobs in isolated git worktrees, exposed as MCP tools and slash commands. Self-contained bundle, no build step to install.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds [`codex-helper`](https://github.com/toniles/codex-helper-plugin) under **Backend & Architecture** (alongside maestro-orchestrate), as an external-repo entry.

**What it is:** a Claude Code plugin (repo-as-marketplace) that orchestrates non-blocking, multi-turn Claude ↔ Codex review dialogues and Codex implementation jobs — plan reviews, aspect-based code reviews, and isolated git-worktree implementation jobs — exposed as MCP tools plus slash commands. The MCP server ships as a self-contained esbuild bundle, so installing needs no build step.

Install:
```
/plugin marketplace add toniles/codex-helper-plugin
/plugin install codex-helper@codex-helper
```

Checklist per your Contributing section:
- Addresses a real use case: cross-model (Claude+Codex) review/delegation from inside Claude Code.
- Doesn't duplicate existing functionality: complements maestro-orchestrate; this one bridges to OpenAI Codex specifically.
- README-only entry pointing to the external repo (same pattern as AgentLint, maestro-orchestrate, etc.); validated locally with `claude plugin validate`.