### PR TITLE
Add Goals to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Goals](https://github.com/ShivamGupta42/goals) - A no-nonsense goal workflow engine. Turns a plain-English goal into tracked steps with plain-language decisions and evidence-based "done". One-line install; works in Claude Code and Codex.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **[Goals](https://github.com/ShivamGupta42/goals)** to the Developer Productivity section.

Goals is a no-nonsense goal workflow engine for Claude Code (and Codex): you give it a goal in plain English, it breaks it into tracked steps, surfaces every decision in plain words, and won't mark a step "done" without evidence. It ships as a Claude Code plugin (`/plugin marketplace add ShivamGupta42/goals`) with a one-line install.

- Addresses a real use case (keeping long agent runs on a plan you can read)
- Doesn't duplicate an existing entry
- Public repo, MIT-licensed