### PR TITLE
Add ultracost plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
-- [ultracost](https://github.com/danielkremen818/ultracost) - Per-stage model routing for `ultracode` dynamic workflows. Pins an explicit model and effort on every `agent()` subagent stage, estimates cost before launch, and ships a static guard plus a PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, MIT.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
 
 ### Documentation & Security
@@ -154,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [ultracost](https://github.com/danielkremen818/ultracost) - Per-stage model routing for any `ultracode` dynamic workflow — frontend, backend, research, refactors, audits, not just one domain. Pins an explicit model + effort on every `agent()` subagent stage, estimates cost before launch, and ships a static guard plus a PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, no telemetry, MIT.
 
 ### Companion & Personality
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
+- [ultracost](https://github.com/danielkremen818/ultracost) - Per-stage model routing for `ultracode` dynamic workflows. Pins an explicit model and effort on every `agent()` subagent stage, estimates cost before launch, and ships a static guard plus a PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, MIT.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
 
 ### Documentation & Security


### PR DESCRIPTION
Adds **ultracost** under **Developer Productivity** as an external-repo plugin.

ultracost is per-stage model routing for Claude Code `ultracode` dynamic workflows — and it applies to **any** kind of work a dynamic workflow does (frontend, backend, research, refactors, audits), not one domain. When `ultracode` is on, every workflow stage inherits the session's Opus model unless pinned (per Anthropic's docs), so a fan-out can silently run grep sweeps and file scans on Opus. ultracost makes the routing explicit: a quality-first policy (Opus for reasoning, Sonnet for mechanical work, never Haiku) injected each session, a static guard that flags stages that would inherit Opus, and a deterministic PreToolUse cost gate that estimates the run and stops the launch for approval.

- Repo: https://github.com/danielkremen818/ultracost
- Install: `/plugin marketplace add danielkremen818/ultracost` → `/plugin install ultracost@ultracost`

**Security & trust**
- **Zero runtime and dev dependencies** — no supply chain to compromise; Snyk Open Source and `npm audit` report 0 vulnerabilities.
- **No telemetry, no network on the hot path** (the only outbound call is the user-invoked `pricing refresh`).
- Releases publish to npm with **OIDC Trusted Publishing + signed provenance**; every GitHub Action is **pinned to a commit SHA**; **CodeQL + OpenSSF Scorecard** run in CI.
- MIT licensed; the installer touches only its own files and is fully reversible.

Checklist:
- [x] Addresses a real use case (silent Opus fan-out cost in ultracode, across any workflow domain)
- [x] Doesn't duplicate existing functionality (no plugin lints inline `agent()` stage pins / tier-mismatch)
- [x] Tested (npm test green; `claude plugin validate` passes)