### PR TITLE
Add ship-gate (pre-push quality gate plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [ship-gate](https://github.com/aksheyw/claude-code-ship-gate) - A pre-push quality gate. A PreToolUse hook blocks pushes to your protected branch until tests, code review, security, and a secret scan pass, so the usual "git push --no-verify" escape does not work. Hardened by a 14-lens review and 3 red-team passes. Claude Code plugin.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [ship-gate](https://github.com/aksheyw/claude-code-ship-gate) under **Code Quality & Testing**.

It is a Claude Code plugin: a PreToolUse hook that blocks `git push` to your protected branch until tests, code review, security, and a secret scan pass. Because the hook runs above git, a `git push --no-verify` cannot skip it. Distinct from the existing `ship` entry (a PR-to-production workflow): ship-gate is the enforcement gate, not a deploy flow.

MIT, dependency-free (bash + jq + awk), with a 265-test suite. The push-detector was hardened by a 14-lens review and 3 red-team passes.