### PR TITLE
Add AccInt plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first MCP memory server and Claude/Codex/OpenCode integration surface that lets coding agents retrieve prior work, route goals through commitments and continuation frames, and record outcome feedback.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary
- add AccInt to the Developer Productivity section
- link to the public AccInt repository
- describe the Claude/Codex/OpenCode MCP memory workflow without adding generated or local plugin artifacts

## Validation
- `git diff --check`
- AccInt GitHub link returns HTTP 200
- checked recent accepted PR style; external additions are README-only entries
