### PR TITLE
Add docx-to-wangeditor-html plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
+- [docx-to-wangeditor-html](https://github.com/naisi-alibaba/docx-to-wangeditor-html) - Convert Word (.docx) into clean HTML that pastes correctly into a wangEditor rich-text editor — preserves headings/bold/tables and de-schemes URLs to avoid the bug that silently flattens the whole document into plain text.
 
 ### Developer Productivity
 


### PR DESCRIPTION
Adds **docx-to-wangeditor-html** under *Documentation & Security*.

**What it does:** Converts Word (.docx) documents into clean semantic HTML that pastes correctly into a **wangEditor** rich-text editor — keeps headings/bold/tables, and de-schemes URLs.

**Problem it solves:** Pasting Word into a wangEditor-based admin/CMS box often loses formatting, or — when the content contains an `http(s)://` URL glued to CJK text — wangEditor's auto-link breaks `insertHTML` and the **entire document flattens into plain text**. This tool emits semantic tags wangEditor preserves and removes URL schemes so the paste never collapses.

- Repo: https://github.com/naisi-alibaba/docx-to-wangeditor-html
- Pure Python stdlib (no deps); MIT; `claude plugin validate` passes; includes a Playwright script that verifies the paste against a live wangEditor.

Install:
```
/plugin marketplace add naisi-alibaba/docx-to-wangeditor-html
/plugin install docx-to-wangeditor-html@docx-to-wangeditor
```