### PR TITLE
Add NotFair — SEO, Google Ads & Meta Ads skills plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Covers site analysis, keyword research, meta tags, schema markup, wasted-spend detection, and Meta ROAS/creative-fatigue audits.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference for the Claude Code community.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** under the Integrations section. It's an open-source Claude Code plugin (~2.9k stars, MIT) that brings marketing and SEO work into Claude Code by connecting to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

The skills cover three areas:
- **SEO/GEO** — site analysis, keyword research, meta tag optimization, schema markup, content writing
- **Google Ads** — campaign audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap audits

It fits naturally in Integrations since its value comes entirely from those MCP connections to live ad and search data.

Happy to reword the description, adjust the section placement, or trim anything if needed — just let me know.