### PR TITLE
Add asqav-claude-code to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
+- [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
 
 ### Developer Productivity
 


### PR DESCRIPTION
Adds [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) to the Documentation & Security section.

**What it does:** A Claude Code plugin that uses session hooks to sign a tamper-evident Asqav receipt when the session stops. Captures file edits (SHA-256 of content before/after), commands run (hashed), and git context. The signed receipt is publicly verifiable at asqav.com/verify. Useful for audit trails, EU AI Act record-keeping, and SOC 2 evidence. Fail-open: a missing API key or network error warns and exits 0, never blocking the session. MIT, free tier.

Proof of work:
- Commit: 38a6e92 (1 insertion, README.md)
- Branch: jagmarques:add-asqav-claude-code → ComposioHQ:master
- Diff stat: 1 file changed, 1 insertion(+)