### PR TITLE
Add Synder gl-importer to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [gl-importer](https://github.com/SynderAccounting/gl-importer-plugin) - Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the Synder Importer API. 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds the **Synder gl-importer** plugin to the **Integrations** section.

**What**
Official Synder plugin: import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools + the \`gl-importer\` agent skill.

**Verification**
- npm: https://www.npmjs.com/package/@cloudbusiness/gl-importer-mcp (v0.1.1, npm provenance + \`mcpName\` field)
- Official MCP Registry: \`com.synder/gl-importer-mcp\` (DNS-authenticated under synder.com)
- Repo: https://github.com/SynderAccounting/gl-importer-plugin
- License: MIT

**Install**
\`\`\`bash
npx -y @cloudbusiness/gl-importer-mcp
\`\`\`