### PR TITLE
Add t3d (DDD + TDD harness) to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [t3d](https://github.com/coolsocket/t3d) - DDD + TDD harness for Python projects. Hooks deny external-framework imports in Domain layers and cross-context internal imports at edit time; block Stop if Domain was edited but tests are red. Ships 4 skills (init, new-context, grill-me, sinkin) and a project template with the 4-layer bounded-context skeleton.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## What

Adds [`t3d`](https://github.com/coolsocket/t3d) to the **Backend & Architecture** section. It's a small Claude Code plugin (5 hooks, 4 skills, project templates) that gives any Python project the same DDD + TDD discipline at edit time.

## Why this section

t3d's primary value is enforcing bounded-context boundaries — closer to architectural patterns than to test-tooling. I'm placing it next to other external-source entries (`maestro-orchestrate`, `mcp-builder`) which is consistent with how the README handles non-Composio plugins.

## What t3d does

- **5 hooks** (PreToolUse / PostToolUse / Stop / UserPromptSubmit) — deny Domain-layer external-framework imports; deny cross-context internal imports; block Stop when Domain was edited but tests are red.
- **4 skills** — `/t3d-init`, `/t3d-new-context`, `/t3d-grill-me`, `/t3d-sinkin` (periodic drift audit + session-log mining).
- **Templates** — `CLAUDE.md`, `CONTEXT-MAP.md`, 4-layer `contexts/_TEMPLATE/`, `_shared_kernel/`, ADR template.

## How to verify

```bash
# In Claude Code:
/plugin marketplace add coolsocket/t3d
/plugin install t3d

# In a fresh directory:
/t3d-init
# Try to write contexts/foo/domain/x.py containing 'import fastapi'
# → PreToolUse hook DENIES the edit with a structured reason
```

Plugin manifest validates cleanly (`claude plugin validate .`), CI green: https://github.com/coolsocket/t3d/actions

## Changes in this PR

One line added to README.md `Backend & Architecture`. No code copied into this repo.