### PR TITLE
Add clawde — context Tamagotchi status-line pet (Companion & Personality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
+- [clawde](https://github.com/adriancisnerosspeed-hub/clawde) - A context "Tamagotchi" that lives in your status line and feeds on a clear context window: keep context low and it thrives, let it fill and it gets sleepy then sick. Grows through life stages, builds daily streaks, switchable skins (buddy/cat/slime), real-time animation, and a catch-the-crumbs mini-game. Pure Python, zero dependencies.
 
 ### Image Generation
 


### PR DESCRIPTION
Adds **clawde** to the **Companion & Personality** section.

[clawde](https://github.com/adriancisnerosspeed-hub/clawde) is a context "Tamagotchi" that lives in your Claude Code status line and feeds on a clear context window — keep context low and it thrives; let it fill toward full and it gets sleepy, then sick, and nags you to `/compact`. It grows through life stages (egg → adult), builds daily feeding streaks, has switchable skins (buddy / cat / slime), a real-time animated `--watch` mode, and a catch-the-crumbs mini-game.

- **Pure Python, zero dependencies** (stdlib only); 13 self-tests.
- MIT licensed.
- Linked to the external repo (like the existing `kaggle-skill` / `AgentLint` entries) rather than vendored in — happy to adjust to match your preference.