### PR TITLE
docs: list the Hermes Tweet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+- [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Hermes Agent and Claude-compatible plugin for X/Twitter search, tweet reading, and explicit action-gated posting.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 
 ### Frontend & Design


### PR DESCRIPTION
## Summary

- List Hermes Tweet in the existing Integrations section.
- Link to the maintained project instead of copying its implementation.
- Describe search, reading, and explicit action-gated posting in one catalog line.

## Repository Fit

Hermes Tweet publishes a Claude plugin manifest and a bundled Skill. The entry
uses this repository's existing link-only format and keeps runtime details in
the maintained upstream project.

## Validation

- Parsed both marketplace JSON files.
- Confirmed the public Hermes Tweet repository and Claude manifest.
- Ran the Git whitespace check.
- Confirmed the branch contains one focused README addition.
