### PR TITLE
Add spotify plugin to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [spotify](https://github.com/ofurkanuygur/claude-spotify) - Show the now-playing Spotify track in your statusline and control playback (next/prev/play, named modes, volume) right from Claude Code. macOS, AppleScript, no login.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds **spotify** to the **Integrations** section.

A Claude Code plugin that shows the now-playing Spotify track in your statusline and controls playback (next/prev/play by URI, named modes, volume) — macOS, AppleScript, no login required.

- Repo: https://github.com/ofurkanuygur/claude-spotify
- Install: `/plugin marketplace add ofurkanuygur/claude-spotify` then `/plugin install spotify`

Checklist:
- **Real use case:** control Spotify and see now-playing in the statusline without leaving Claude Code.
- **No duplication:** no existing Spotify / now-playing plugin in the list.
- **Tested:** installed end-to-end via `claude plugin install` (marketplace add + install succeed); `claude plugin validate --strict` passes; playback control and statusline verified against the live Spotify desktop app on macOS.