### PR TITLE
Add automatic-episodic-memory to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [automatic-episodic-memory](https://github.com/automattf/automatic-episodic-memory) - Episodic memory with automatic recall for Claude Code: captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds automatic-episodic-memory.

Episodic memory with automatic recall for Claude Code: it captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.

How it differs from other memory plugins: most memory and notes plugins are recall-on-demand or manual-capture, where the agent has to remember to log a memory and to query for it. This one automates both ends. Capture runs automatically when the context window compacts, and recall is hook-driven, surfacing the relevant past episode on its own before the agent reasons. That hands-free automatic recall is the distinguishing feature, so this is not a duplicate of existing memory entries.

Repo: https://github.com/automattf/automatic-episodic-memory
Install: `/plugin marketplace add automattf/claude-plugins` then `/plugin install automatic-episodic-memory@automattf-plugins`