### PR TITLE
Add lore (learnings system for Claude Code & Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [lore](https://github.com/aoc81/lore) - Self-maintaining learnings system for Claude Code & Codex. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context and a `PreToolUse` hook surfaces file-specific gotchas at edit time; a `Stop` hook nudges capture of only non-obvious, reusable facts. Ships a freshness linter (flags entries whose referenced code changed) and a blocking pre-push secret scan. Plain-markdown store committed in your repo; stdlib Python, zero deps, no network.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **lore** under **Developer Productivity**.

- Repo: https://github.com/aoc81/lore
- License: MIT

lore is a self-maintaining learnings system. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context, a `PreToolUse` hook surfaces file-specific gotchas at edit time, and a `Stop` hook nudges capture of only non-obvious, reusable facts. It ships a freshness linter (flags entries whose referenced code changed) and a blocking pre-push secret scan over the store. The store is plain markdown committed in your repo, so a whole team benefits.

Checklist:
- [x] Addresses a real use case (durable, low-effort knowledge capture/recall across sessions)
- [x] Does not duplicate existing functionality
- [x] Follows the existing one-line entry format
- [x] Tested (Claude Code + Codex); stdlib Python, zero deps, no network calls