### PR TITLE
Add usage-guard (usage-monitoring plugin) to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [usage-guard](https://github.com/eltonylfgi-blip/claude-code-usage-guard) - A Claude Code plugin (Stop hook + /usage command) that warns you in-session when you're burning through your usage fast. Zero dependencies, reads local transcripts only, no network calls.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds **usage-guard** to the **DevOps & Performance** section.

**What it is:** a Claude Code plugin that warns you *in-session* when you're burning through your usage fast. A `Stop` hook checks your recent token usage after each turn and drops one short line (e.g. `⚠️ Near budget: 81% (14.7M of 18.0M) in 5h`) when you cross a budget you set, throttled so it never spams. It also ships a `/usage-guard:usage` command to check spend on demand.

- **Repo:** https://github.com/eltonylfgi-blip/claude-code-usage-guard
- **License:** MIT
- **Zero dependencies**, reads only your local session transcripts, **no network calls / no telemetry**.
- Fits alongside `aws-cost-saver` and `Manifest` (usage/cost monitoring).

Single README line, added at the end of the section. Thanks for maintaining the list!