### PR TITLE
Add whoami plugin (Developer Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [whoami](https://github.com/luckeyfaraday/whoami) - Scans the machine and interviews the user to build a portable profile, giving any AI coding agent instant context about who the user is and what they work on. Runs locally, redacts secrets, and outputs a single Markdown profile.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **whoami** to *Developer Productivity*.

[whoami](https://github.com/luckeyfaraday/whoami) is an open-source Claude Code plugin that scans a developer's machine and interviews them to build a portable profile, so any AI coding agent loads instant context about who the user is and what they work on instead of starting cold.

- Installable via `/plugin marketplace add luckeyfaraday/whoami` then `/plugin install whoami@luckeyfaraday`.
- Runs entirely locally with zero network calls; redacts secrets and never prints personal-document contents.
- Reads AI-agent session history across Claude Code, Codex, Droid, OpenCode, Gemini, and Qwen.
- Outputs a single Markdown profile (`~/.whoami/profile.md`). MIT licensed.