### PR TITLE
Add ophis plugin (gasless, MEV-protected onchain swaps for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [ophis](https://github.com/ophis-fi/skills) - Gasless, MEV-protected onchain token swaps for AI agents across 11 EVM chains. An intent-based DEX (a CoW Protocol deployment) that is keyless and non-custodial; bundles the 12-tool Ophis MCP server and the ophis-swap workflow skill. Note: this is Ophis the DeFi DEX (ophis.fi), not the unrelated njayp/ophis Go library.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## What this adds

One README bullet under Integrations for **ophis**, a Claude Code plugin that gives an AI agent gasless, MEV-protected onchain token swaps across 11 EVM chains (Ethereum, Optimism, BNB Chain, Gnosis, Polygon, Base, Arbitrum, Avalanche, Plasma, Ink, Linea).

Ophis is an intent-based DEX, a deployment of CoW Protocol. Swaps settle through a solver competition, so they are MEV-protected, gasless for the trader (no native coin needed for gas), keyless (the MCP server is public, no API key), and non-custodial (the server builds an unsigned order, the agent signs it with its own wallet, and the receiver is pinned to the signer). The plugin bundles a 12-tool remote MCP server plus the ophis-swap workflow skill that teaches the safe order of operations for a trade. submit_order is the only state-changing tool.

Install:

    /plugin marketplace add ophis-fi/skills
    /plugin install ophis@ophis-fi

Source repo (follows the standard plugin structure): https://github.com/ophis-fi/skills
Project: https://ophis.fi  App: https://swap.ophis.fi

## Disambiguation

This is Ophis the DeFi DEX (ophis.fi). It is not the unrelated njayp/ophis Go MCP library. Different project, different domain.

## Why README-only (no marketplace.json change)

ophis is hosted in its own repo, so I followed the established convention for externally-hosted plugins in this list (kaggle-skill and others): a single README bullet linking to the source repo. The marketplace.json manifests only contain plugins vendored into this repo with a local "./folder" source, so adding ophis there would mean copying the whole plugin in and duplicating the upstream source of truth. Happy to vendor it instead if you prefer that path.

## Contributing checklist

- Addresses a real use case: lets an agent execute real onchain swaps safely.
- Does not duplicate existing functionality: no other onchain-swap or DeFi plugin is listed.
- Follows the template structure: the ophis-fi/skills repo uses the standard .claude-plugin marketplace and plugin layout.
- Tested: the plugin and its remote MCP server (https://mcp.ophis.fi/mcp) are live and published; MCP Registry id fi.ophis/mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
