### PR TITLE
Add Prompt Pocket under Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Prompt Pocket](https://github.com/lxb12123/prompt-pocket) - Cross-agent prompt manager that surfaces your most-used prompts in each agent's native slash menu. One shared store at ~/.prompt-pocket/store.json, with optional auto-recording of prompts repeated 7+ times by scanning Claude Code, Codex & OpenCode session history.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **Prompt Pocket** to the **Developer Productivity** section (external-link entry, like CCHub / context-mode / agntk / backlog).

- Repo: https://github.com/lxb12123/prompt-pocket
- License: MIT
- Cross-agent prompt manager that puts your most-used prompts into each agent's native slash menu. One shared store at `~/.prompt-pocket/store.json` that every agent reads; optional auto-recording of prompts repeated 7+ times by scanning Claude Code, Codex & OpenCode session history. Works on Claude Code, Codex, OpenCode, Cursor, Copilot & Gemini CLI.

Single-line addition; links verified public.