### PR TITLE
Add BankBridge plugin to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Integrations
 
+- [bankbridge](https://github.com/bankbridge-money/bankbridge-plugin) - Read-only bank access for Claude. 19 slash commands wrapping a hosted MCP server — balances, monthly cashflow, subscription audit, tax prep, budget draft, portfolio health, and more. Plaid-backed; no financial data cached.
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 


### PR DESCRIPTION
Adds **BankBridge** to the Integrations section.

**What it is:** A Claude Code plugin shipping 19 slash commands that wrap a hosted MCP server, giving Claude read-only access to your real bank accounts via a secure bank link flow.

**Commands:** \`/balances\`, \`/monthly-check\`, \`/subscriptions\`, \`/portfolio-health\`, \`/budget-draft\`, \`/price-creep\`, \`/year-in-review\`, \`/spending-by\`, \`/compare-months\`, \`/cashflow-trend\`, \`/dividends\`, \`/tax-prep\`, \`/duplicate-check\`, \`/fraud-check\`, \`/monthly-report\`, and more.

**Links:**
- Plugin repo: https://github.com/bankbridge-money/bankbridge-plugin
- Skills repo: https://github.com/bankbridge-money/bankbridge-skills
- Site: https://bankbridge.money
- Also on the Official MCP Registry as \`money.bankbridge/server\`

Pricing: \$5/month per connected bank, first month free.
