### PR TITLE
Add crewcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [crewcut](https://github.com/marcusbellamyshaw-cell/crewcut) - Lazy senior dev mode that also refuses to guess. Merges the YAGNI/minimalism ladder from `ponytail` with the assumption-surfacing and goal-driven-execution principles from `andrej-karpathy-skills`. Adds a `/crewcut-review` that catches scope creep and unflagged assumptions (not just bloat) and a `/crewcut-plan` skill for scoping ambiguous tasks before coding.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [crewcut](https://github.com/marcusbellamyshaw-cell/crewcut) to Developer Productivity.

Lazy senior dev mode for Claude Code that also refuses to guess: combines ponytail's YAGNI/minimalism ladder with andrej-karpathy-skills' assumption-surfacing and goal-driven-execution principles into one always-active plugin, plus a review command that flags scope creep and silent assumptions (not just bloat) and a standalone planning skill. Full attribution to both source projects in the repo's NOTICE.md.

MIT licensed, external link only (no folder added to this repo).