### PR TITLE
Add optionsahoy plugin under Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [optionsahoy](https://github.com/AlvisoOculus/optionsahoy-claude-plugin) - Deterministic US equity-compensation tax optimizer. Bundles a hosted MCP server plus a planning skill for incentive stock option (ISO) and alternative minimum tax (AMT) planning, non-qualified stock option (NSO) and restricted stock unit (RSU) decisions, single-stock concentration, protective puts, qualified small business stock (QSBS) checks, and equity funding plans.
 
 ### Frontend & Design
 


### PR DESCRIPTION
One README entry under Integrations, matching the existing external-link format (same pattern as kaggle-skill).

- [optionsahoy](https://github.com/AlvisoOculus/optionsahoy-claude-plugin): deterministic US equity-compensation tax optimizer for Claude Code. It bundles a hosted MCP server (https://optionsahoy.com/mcp, HTTP, no auth key) plus one planning skill that routes to the right tool and captures required inputs.
- Real use case: incentive stock option (ISO) exercise and alternative minimum tax (AMT) planning, non-qualified stock option (NSO) and restricted stock unit (RSU) decisions, single-stock concentration, protective puts, qualified small business stock (QSBS) checks, and equity funding plans. Federal plus 50-state plus DC tax math, computed deterministically rather than generated.
- No duplicate of anything on the list; MIT licensed; installable today via /plugin marketplace add AlvisoOculus/optionsahoy-claude-plugin then /plugin install optionsahoy@alphalatitude. Tested end to end with claude plugin validate and a live install.