### PR TITLE
Add Loamkit (WordPress/WooCommerce starter kit) to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [Loamkit](https://github.com/jaymadeapp/Loamkit) - Security-first WordPress/WooCommerce starter kit. An interactive setup skill scaffolds Bedrock + Sage 11 projects with an art-directed design system (6 theme.json directions), role-based agents, a Playwright design-review gate, and fail-closed guard hooks that keep the database and payment paths out of the agent's hands.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## What

Adds **[Loamkit](https://github.com/jaymadeapp/Loamkit)** — a security-first WordPress/WooCommerce starter kit shipped as a Claude Code plugin — as a link entry under **Backend & Architecture** (same external-repo entry style as kaggle-skill, AgentLint, maestro-orchestrate).

## Why it qualifies

- **Real use case:** turns a blank directory into a production-shaped Bedrock + Sage 11 WordPress project (or WooCommerce shop) via an interactive setup skill; used on real client work.
- **No duplication:** there is no WordPress/WooCommerce scaffolding plugin on the list.
- **Standard plugin structure:** `.claude-plugin/plugin.json`, 5 skills, 8 agents, PreToolUse hooks, `.mcp.json` — installable via `/plugin marketplace add jaymadeapp/Loamkit` → `/plugin install loamkit@loamkit`.
- **Tested:** the fail-closed guard hooks ship with a 48-case self-test (`scripts/test-guards.sh`), and CI lints every script/template/JSON. Distinctives: a two-lane data-safety invariant enforced by command-parsing hooks (code up via git, DB down only), a hard human gate on WooCommerce checkout/payment paths, and a six-direction art-directed design system with a Playwright design-review hard-fail gate.

MIT licensed. Happy to move it to another category if you'd place it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)