### PR TITLE
Add fable-mode (Companion & Personality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
+- [fable-mode](https://github.com/rennf93/opus-fable-playbook) - Makes Opus 4.8 behave like Claude Fable 5 via a doctrine output style, drift-catching hooks (stop-gate, tool-discipline, honesty nudges), three skills, and a critic agent, validated by a 12-probe eval loop judged pairwise against golden Fable transcripts.
 
 ### Image Generation
 


### PR DESCRIPTION
Adds fable-mode to Companion & Personality.

fable-mode is a Claude Code plugin that makes Opus 4.8 behave like Claude Fable 5. It combines a doctrine output style (transcribed by Fable 5 itself), seven fail-open hooks that catch behavioral drift at the harness level (blocking promise-only turn endings, denying shell file-reads in favor of Read/Grep, nudging verbatim failure reporting), three skills, and a critic agent. Convergence is measured, not claimed: a 12-probe eval loop judges it pairwise against golden Fable 5 transcripts, and both eval reports (including the dimensions where it loses) are committed in the repo.

Checklist per your contributing notes: real use case (running Opus sessions under Fable's behavioral contract); no duplicate of an existing entry (closest neighbor is claude-familiar, which does companion personality — fable-mode does model-behavior doctrine with enforcement and evals); tested — 64-case suite, CI on ubuntu and macos, released v0.1.2. Install: `/plugin marketplace add rennf93/opus-fable-playbook`.
