### PR TITLE
Add x-skills to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [x-skills](https://github.com/sergebulaev/x-skills) - 6 Claude Code and Codex skills for writing on X (Twitter): post writer, thread builder, hook extractor, humanizer, reply drafter, and content planner. MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds one entry for x-skills under Developer Productivity.

x-skills is a bundle of 6 Claude Code and Codex skills for writing on X (Twitter): post writer, thread builder, hook extractor, humanizer, reply drafter, and content planner. It is installable via the Claude Code plugin marketplace with `/plugin marketplace add sergebulaev/x-skills`.

- Repo: https://github.com/sergebulaev/x-skills
- License: MIT

The change is a single list line appended to the Developer Productivity section, matching the existing external-repo entry format. No other files touched.