### PR TITLE
Add claude-session-triage to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-session-triage](https://github.com/eltonylfgi-blip/claude-session-triage) - Scans every local Claude Code session across all your projects, finds the ones idle long enough to count as abandoned, and reports which still have an open decision waiting on you. Zero dependencies, no network calls.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **claude-session-triage** to the **Developer Productivity** section.

**What it is:** scans every local Claude Code session across all your projects, finds the ones idle long enough to count as abandoned (default 4h no activity), and reports which ones still have an open decision waiting on you — without you having to remember which window/project each one was in.

- **Repo:** https://github.com/eltonylfgi-blip/claude-session-triage
- **License:** MIT
- **Zero dependencies**, reads only local session transcripts, **no network calls**.
- Different from recall/memory plugins (which answer "what did we discuss last time" on demand): this one proactively flags which *currently idle* sessions still have something open. Also different from live-session monitors (Agent View, session dashboards): those watch running sessions, this does archaeology on the ones that went quiet.
- Ships a `/session-triage:panel` skill plus a standalone `npx claude-session-triage` CLI.
- Correctly excludes Claude Code's own scheduled-task/routine sessions (detected via the `<scheduled-task>` marker) so cron jobs never show up as "pending decisions".

Single README line, added at the end of the section. Thanks for maintaining the list!