### PR TITLE
Add agent-preflight Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
+- [agent-preflight](./agent-preflight) - Claude Code slash command that runs a lightweight repo-safety preflight before agent shell/tool use, flags agent/MCP config, risky scripts, workflow files, and secret-adjacent files, then turns the result into Green/Yellow/Red run/ask/avoid guidance.
 
 ### Developer Productivity
 

--- a/agent-preflight/.claude-plugin/plugin.json
+++ b/agent-preflight/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "agent-preflight",
+  "version": "0.1.0",
+  "description": "Claude Code slash command for a lightweight repo-safety preflight before agent shell/tool use.",
+  "author": {
+    "name": "Agent Safety Starter Pack"
+  }
+}

--- a/agent-preflight/README.md
+++ b/agent-preflight/README.md
@@ -1,0 +1,26 @@
+# Agent Preflight
+
+Run a lightweight repo-safety preflight before giving Claude Code shell/tool access in an unfamiliar repository.
+
+## Use
+
+From this awesome-claude-plugins checkout:
+
+```bash
+claude --plugin-dir ./agent-preflight
+```
+
+Then run the slash command in Claude Code:
+
+```text
+/agent-preflight /path/to/repo
+```
+
+The command asks Claude to run the free `agent_preflight_lite.py` scanner from the public source repo when it is available, then produce a Green / Yellow / Red handoff with:
+
+- risk buckets found,
+- files the agent should avoid,
+- commands the agent must ask before running,
+- safe first commands.
+
+Source scanner and examples: <https://github.com/el-zachariah/ai-agent-safety-starter-pack>

--- a/agent-preflight/commands/agent-preflight.md
+++ b/agent-preflight/commands/agent-preflight.md
@@ -1,0 +1,30 @@
+---
+description: Run a lightweight repo-safety preflight before Claude Code gets shell/tool access
+argument-hint: [repo-path]
+---
+
+You are preparing to work in a repository with Claude Code or another local AI coding agent.
+
+Target repository path: `$ARGUMENTS` (if blank, use the current working directory).
+
+Before installing dependencies, running package scripts, editing agent config, or executing shell commands:
+
+1. Resolve the target path and confirm it is the repository you are about to work in.
+2. If the free scanner is present in the workspace, run:
+
+   ```bash
+   python3 agent_preflight_lite.py "$ARGUMENTS" --json
+   ```
+
+   If `$ARGUMENTS` is blank, use `.` instead.
+3. If the scanner script is not present, fetch or inspect the free source repo first: `https://github.com/el-zachariah/ai-agent-safety-starter-pack`.
+4. Convert findings into a Green / Yellow / Red decision:
+   - Green: 0-1 low-risk buckets; continue with normal review discipline.
+   - Yellow: 2-3 buckets; write may-run / must-ask / must-not-touch rules before tool use.
+   - Red: 4+ buckets, secret-adjacent files, destructive shell, or agent/MCP config; stop and add guardrails before tool use.
+5. Produce a short handoff note with:
+   - risk buckets found,
+   - files the agent should not touch,
+   - commands the agent must ask before running,
+   - safe first commands to run.
+6. Do not run package scripts, install hooks, edit credentials, or mutate CI until the handoff note exists.


### PR DESCRIPTION
## Summary
- add a free `agent-preflight` Claude Code plugin folder
- add a `/agent-preflight` slash command for repo-safety preflight before shell/tool use
- list it under Documentation and Security in the README

## Verification
- `python3 -m json.tool agent-preflight/.claude-plugin/plugin.json`
- local README assertion: exactly one `agent-preflight` entry plus manifest and command files exist

The command links to the public free scanner/source repo and does not include paid-product links.
