### PR TITLE
Add manifest-dev plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [manifest-dev](https://github.com/doodledood/manifest-dev) - Manifest-driven workflow: /figure-out presses until the problem is understood, /define writes down what you'd accept, /do executes with one independent verifier per criterion so it can't declare done on a self-report.
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
-
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.


### PR DESCRIPTION
What problem it solves: coding agents start building before the problem is understood and report done on self-assessment. manifest-dev separates understanding (/figure-out), acceptance definition (/define), and verified execution (/do) — one independent verifier per criterion decides done.

Who uses it: developers handing larger tasks to a coding agent who want a stop condition they can trust.
Attribution: original work, doodledood/manifest-dev (MIT).

Example: /figure-out "why do half my background jobs silently stall?" — it investigates the repo and presses the load-bearing question before any fix. 

Individual skills install via npx skills add doodledood/manifest-dev --skill figure-out.
