### PR TITLE
Add adp-fase-zero plugin to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [adp-fase-zero](https://github.com/murilomn58/Claude-Spec-Driven-Fase-Zero) - Spec-driven "Phase Zero" for Claude Code: a reverse-interview skill (`grill-me`) that researches the state of the art (GitHub, HN, Reddit) and grills every assumption, then `to-prd` turns the conversation into a PRD — before any code is written. Content is PT-BR (built for BR devs first); the methodology is language-agnostic. MIT.
+  
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
Adds adp-fase-zero to the Developer Productivity section.

  It's an open-source (MIT) Claude Code plugin for the "Phase Zero" of feature work:
  a reverse-interview skill (grill-me) that first researches the state of the art
  (GitHub, HN, Reddit, dev.to, Product Hunt) and challenges each assumption, then a
  to-prd skill that synthesizes the conversation into a PRD — all before writing code.

  - Repo: https://github.com/murilomn58/Claude-Spec-Driven-Fase-Zero
  - Native install: /plugin marketplace add murilomn58/Claude-Spec-Driven-Fase-Zero
    then /plugin install adp-fase-zero@adp
  - License: MIT

  - Repo: https://github.com/murilomn58/Claude-Spec-Driven-Fase-Zero
  - Native install: /plugin marketplace add murilomn58/Claude-Spec-Driven-Fase-Zero
    then /plugin install adp-fase-zero@adp
  - License: MIT

  Disclosure: the plugin content and docs are in Portuguese (BR) — built for Brazilian
  devs first — but the methodology is language-agnostic (Claude follows the PT-BR skills
  and replies in the dev's language). A paid full version of the broader protocol also
  exists, but this entry is only for the free, open-source Phase Zero.

  Checklist per the README Contributing section: real use case; no duplication (no
  existing spec/PRD-discovery plugin in the list); follows plugin template structure; tested.