### PR TITLE
Add prd-maker to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [prd-maker](https://github.com/jcmaker/prd-maker) - Turns a product idea into an agent-executable PRD.md through an adaptive interview. Works for non-developers, outputs pure markdown, and supports Claude Code and Codex.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **prd-maker** under **Developer Productivity**.

**What it is:** an interview-driven PRD generator. It asks about your product idea (adapting the questions to your technical level) and produces a `PRD.md` that an AI coding agent can execute directly.

**Why it fits this list:**
- It's a Claude Code plugin (`.claude-plugin/`), and also ships a Codex plugin manifest — cross-agent.
- Genuine use case: turning a vague idea into an agent-executable spec, with explicit non-goals, machine-verifiable acceptance criteria, and phased scope.
- Not a duplicate — I searched the README and there's no existing PRD / spec-generation plugin.
- Tested: CI runs a linter test suite + structure/manifest checks on every PR (badge in the repo).

Entry:
`- [prd-maker](https://github.com/jcmaker/prd-maker) - Turns a product idea into an agent-executable PRD.md through an adaptive interview. Works for non-developers, outputs pure markdown, and supports Claude Code and Codex.`

Thanks for maintaining the list!