### PR TITLE
Add mindpowers problem-first knowledge-work plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
-- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Socratic brainstorming for knowledge-work docs (PRDs, business reviews, decision docs) with two approval gates before drafting; a cousin of superpowers for non-code work.
+- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Problem-first knowledge-work plugin for validating evidence, shaping rough ideas into locked specs, drafting and reviewing documents, and remembering preferences. Ships five skills for Claude Code and Cowork, with Agent Skills packaging for Codex, ChatGPT desktop, and Cursor.
 
 ### Companion & Personality
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Socratic brainstorming for knowledge-work docs (PRDs, business reviews, decision docs) with two approval gates before drafting; a cousin of superpowers for non-code work.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [mindpowers](https://github.com/rohitgehe05/mindpowers), a problem-first knowledge-work plugin for PRDs, business reviews, decision documents, one-pagers, and other non-code writing.

The current v0.7.1 suite contains five skills:

- `validating-problems` tests claims against available evidence before a direction is pitched.
- `mindstorming` turns a rough idea into a locked spec through Socratic dialogue and two approval gates.
- `drafting` produces the deliverable from the locked spec.
- `reviewing-docs` pressure-tests documents against their intended standard.
- `calibrating` records preferences and lessons for future sessions.

It ships as a Claude Code marketplace plugin and Cowork ZIP, with native Agent Skills packaging for Codex, ChatGPT desktop, and Cursor. The v0.7.1 Claude and Codex install paths have been validated.
