### PR TITLE
Add backend-security plugin (security category)

### DIFF
--- a/backend-security/.claude-plugin/plugin.json
+++ b/backend-security/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "backend-security",
+  "displayName": "Backend Security",
+  "version": "0.2.0",
+  "description": "Defensive backend security for Claude Code: full-codebase audits, dependency and config scanning, secure-coding guidance while you write, and a phased zero-to-hardened roadmap. Stack-aware with a Node/TS deep-dive; anchored to OWASP Top 10 2021, ASVS 4.0, and CWE.",
+  "author": {
+    "name": "Ghostfreak-cypher",
+    "url": "https://github.com/Ghostfreak-cypher"
+  },
+  "homepage": "https://github.com/Ghostfreak-cypher/backend-security-skill",
+  "repository": "https://github.com/Ghostfreak-cypher/backend-security-skill",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "appsec",
+    "owasp",
+    "asvs",
+    "audit",
+    "backend",
+    "api",
+    "vulnerability",
+    "code-review",
+    "hardening"
+  ]
+}

--- a/backend-security/skills/backend-security/SKILL.md
+++ b/backend-security/skills/backend-security/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: backend-security
+description: Backend security audit, dependency/config scanning, and secure-coding guidance. Use when the user asks for a security audit or review of a backend, API, or server codebase, asks "is this secure" or "find vulnerabilities", wants dependencies, Dockerfiles, or CI configs scanned for security issues, or when writing or modifying backend authentication, authorization, API endpoints, database queries, file uploads, or secrets handling.
+---
+
+# Backend Security
+
+You are performing defensive security work: finding and fixing vulnerabilities in code the user owns. Be precise, evidence-driven, and allergic to false positives — a report padded with speculative findings destroys trust.
+
+## Pick a mode from how you were invoked
+
+- **Audit** — "audit this backend", "find vulnerabilities", "security review the codebase" → run the full workflow below.
+- **Scan** — "scan dependencies", "check the Docker/CI config" → run only Step 4.
+- **Guide** — you are writing or modifying backend code (endpoints, auth, queries, uploads) → do not produce a report; build the code securely by following the relevant reference files, and briefly note the security decisions you made (e.g. "parameterized the query; added ownership check on the lookup").
+- **Harden** — "secure this backend from scratch", "make this production-ready", "take this to enterprise grade" → read `references/roadmap.md` and run the phased zero→hardened engagement. Report phase-by-phase status against its ASVS exit criteria instead of the flat findings table. Use this when the goal is *building up* a baseline, not just *finding* what's broken.
+
+Before anything else, read **Scope & limits** at the bottom of this file so you set honest expectations — this skill is one strong pillar of security, not a substitute for a professional audit, pentest, or compliance program.
+
+## Step 1: Detect the stack
+
+Check for manifests at the repo root (and in service subdirectories for monorepos):
+
+| Manifest | Stack | Extra reference to read |
+|---|---|---|
+| `package.json` | Node.js / TypeScript | `references/nodejs.md` (always read for Node) |
+| `requirements.txt`, `pyproject.toml`, `Pipfile` | Python | — |
+| `go.mod` | Go | — |
+| `pom.xml`, `build.gradle` | Java / Kotlin | — |
+| `composer.json` | PHP | — |
+| `Gemfile` | Ruby | — |
+| `*.csproj` | .NET | — |
+
+The general reference files apply to every stack; translate the grep patterns and idioms to the detected language. If multiple stacks exist (e.g. Node API + Python worker), cover each.
+
+## Step 2: Map the attack surface (Audit mode)
+
+Do not review file-by-file. Review **data flow: untrusted input → dangerous sink**. First build a map of:
+
+1. **Entry points** — routes, controllers, GraphQL resolvers, webhook handlers, message consumers, cron jobs that read external data.
+2. **The auth boundary** — which middleware/decorator enforces authentication, and which routes bypass it (intentionally or not).
+3. **Sinks** — DB queries, shell/process execution, file reads/writes, outbound HTTP, template rendering, deserialization.
+4. **Trust decisions** — every place the code reads a user id, role, tenant, or price/amount: does it come from the session/token (trusted) or from the request body/params (attacker-controlled)?
+
+## Step 3: Domain review (Audit mode)
+
+Read each reference file and hunt for its checks against the map from Step 2. Each file opens with **Coverage anchors** mapping its checks to OWASP Top 10 2021, ASVS 4.0, and CWE — cite these in findings so coverage is auditable:
+
+1. `references/injection.md` — injection classes, SSRF, traversal, deserialization, uploads, open redirect
+2. `references/auth.md` — authentication, password policy, sessions, JWT, access control, IDOR
+3. `references/infra.md` — secrets, config, CORS, headers, rate limiting, TLS, data-at-rest, Docker, CI
+4. `references/nodejs.md` — only when the stack is Node.js/TypeScript
+5. `references/roadmap.md` — only in **Harden** mode (phased build-up, not a findings pass)
+
+## Step 4: Dependency & config scan
+
+Read `references/deps.md` and follow it: run the ecosystem's audit tool, check lockfile hygiene, and review Dockerfile/CI/env handling.
+
+## Step 5: Verify before reporting
+
+For every candidate finding:
+- **Trace it**: confirm attacker-controlled data actually reaches the sink. Name the path (e.g. `req.query.path` → `resolveFile()` → `fs.readFile`).
+- **Check reachability**: is the endpoint exposed? Behind auth? Dead code?
+- **Check existing mitigations**: framework auto-escaping, ORM parameterization, validation middleware upstream. If mitigated, drop it or downgrade to hardening advice.
+- If you cannot confirm exploitability but the pattern is dangerous, report it honestly as "needs verification" — never present speculation as fact.
+
+## Severity rubric
+
+- **Critical** — exploitable pre-auth with severe impact: SQL injection on a public endpoint, auth bypass, RCE, live production credentials committed to the repo.
+- **High** — exploitable by an authenticated user or under realistic conditions: IDOR, weak/hardcoded JWT secret, stored XSS, SSRF to internal services.
+- **Medium** — requires chaining or unusual conditions, or a meaningful hardening gap: missing rate limit on login, CORS reflecting Origin with credentials, verbose stack traces to clients.
+- **Low** — defense-in-depth: missing security headers, missing cookie flags on non-sensitive cookies, outdated dep with no known reachable vuln.
+
+## Report format (Audit and Scan modes)
+
+```markdown
+# Security Review — <repo/service name> (<date>)
+
+**Scope:** <what was reviewed> · **Not reviewed:** <what was out of scope and why>
+
+| # | Severity | Finding | Location |
+|---|----------|---------|----------|
+
+## Findings
+
+### [SEC-1] <Title> — <Severity>
+- **Location:** `path/file.ts:42`
+- **Evidence:** <the vulnerable code and the input→sink path>
+- **Impact:** <what an attacker gains, concretely>
+- **Fix:** <ready-to-apply code>
+
+## Hardening recommendations
+<Low-severity / defense-in-depth items, briefly>
+```
+
+Finding nothing in a domain is a valid result — say "reviewed, no issues found", never invent findings to fill severity levels.
+
+## Rules
+
+- **Never apply fixes without approval.** Propose fix code in the report; edit files only after the user says to. Never commit.
+- Every finding gets a `file:line` reference and real evidence from the code.
+- Prefer fixing code over adding dependencies; suggest new security libraries only when hand-rolling would be worse (e.g. crypto, rate limiting).
+- State clearly what you did **not** review (infrastructure you can't see, runtime config, third-party services).
+- If the codebase is large, tell the user your prioritization (auth + payment + upload paths first) rather than silently sampling.
+
+## Scope & limits
+
+State these plainly to the user — overclaiming is the fastest way to give false confidence. This skill covers **one pillar** of security: the application code and repo-visible configuration.
+
+**What it does well:** systematic source-level review of the vulnerability classes in the reference files, data-flow reasoning to cut false positives, live dependency scanning (delegated to `npm audit` / `pip-audit` / `osv-scanner` / `govulncheck`, so CVE data is always current), and a phased path to a strong ASVS L1–L2 application baseline.
+
+**What it is not, and cannot replace:**
+- **Not a SAST/DAST tool.** It is LLM-guided review: thorough but not exhaustive or provable. It does no runtime testing, fuzzing, or exploitation. On large codebases it prioritizes rather than covering every line — say so.
+- **Not infrastructure or operations security.** It sees only what's in the repo — not your cloud IAM, network segmentation, WAF, secrets manager, or running config. It cannot set up monitoring, alerting, or 24/7 incident response.
+- **Not a compliance or certification exercise.** It does not produce SOC 2 / ISO 27001 / PCI evidence, and it is **not a substitute for a professional penetration test or human security audit** before you stake real user data or money on it.
+- **Static knowledge ages.** Library-specific advice reflects the author's knowledge cutoff; treat version-specific notes as prompts to verify against current advisories, not gospel.
+
+The honest bottom line: this skill makes a backend meaningfully more secure and can build a solid baseline from zero — but "all checks pass" means *the application-layer baseline is strong*, not *this system is enterprise-certified secure*. Recommend a professional pentest and infra/ops review before high-stakes launch.

--- a/backend-security/skills/backend-security/references/auth.md
+++ b/backend-security/skills/backend-security/references/auth.md
@@ -1,0 +1,62 @@
+# Authentication & Access Control
+
+**Coverage anchors** — OWASP Top 10 2021: A01 Broken Access Control, A07 Identification & Authentication Failures, A04 Insecure Design. ASVS 4.0: V2 (Authentication), V3 (Session Management), V4 (Access Control). CWE: 287, 862, 863, 639, 384, 613, 307, 522, 620.
+
+Two questions dominate this domain: **who are you** (authn) and **what may you touch** (authz). Broken object-level authorization (IDOR) is the single most common real-world backend vulnerability — check it on every route that takes an ID.
+
+## Password storage
+
+- **Require:** bcrypt (cost ≥ 10), argon2id, or scrypt. Flag: MD5, SHA-1, unsalted/plain SHA-256, plaintext, reversible encryption, home-rolled hashing.
+- Hash comparison must be the library's verify function, not `==` on hashes.
+- Hunt: `md5(`, `sha1(`, `createHash('sha256').update(password`, `hashlib.md5`, columns named `password` populated without a hash call.
+
+## Password policy
+
+- **Minimum length** enforced server-side (≥8, prefer ≥12). Flag validation that accepts trivially short passwords — e.g. a regex like `/^.{1,20}$/` sets only a *maximum* and permits a 1-character password.
+- Reject known-breached / top-common passwords (e.g. a HaveIBeenPwned range check or a common-password list). Don't impose arbitrary composition rules that push users toward predictable patterns (`Password1!`).
+- No low upper bound that forces truncation; bcrypt's 72-byte limit should be handled, not worked around by capping user length short.
+- Hunt: signup/reset validators (`PASS_RE`, `password.length`, joi/zod `.min()`/`.max()` on password) — confirm a real minimum exists and is applied on **both** registration and password-change/reset paths.
+
+## JWT
+
+- **`decode` vs `verify`:** `jwt.decode()` (Node `jsonwebtoken`, PyJWT with `verify=False`/no key) does NOT check the signature. Any token trusted after mere decoding is a full auth bypass. Hunt: `jwt.decode(` and confirm a separate `verify` guards the trust decision.
+- **Algorithm confusion:** verification must pin an algorithm allowlist (`algorithms: ['RS256']`). Accepting `none`, or verifying RS256 tokens with the public key as an HMAC secret (HS256 confusion), is a bypass.
+- **Secret strength:** HMAC secrets must be long random values from env/secret store — flag short/dictionary strings, secrets committed to the repo, the same secret across environments.
+- **Claims:** enforce `exp` (and reasonable lifetime), validate `iss`/`aud` in multi-service setups. Don't put authorization data the user can pick (role from a request) into the token.
+- **Revocation:** long-lived tokens with no revocation path (logout, password change, ban) — flag as High for sensitive apps. Refresh tokens: stored hashed, rotated on use, revocable.
+
+## Sessions & cookies
+
+- Session cookies: `HttpOnly`, `Secure`, `SameSite=Lax` or `Strict`. Session ID regenerated on login (fixation) and invalidated server-side on logout.
+- Absolute + idle expiry for sensitive apps. Session data server-side; if using signed cookie sessions, nothing sensitive inside and strong signing key.
+- CSRF: if auth is cookie-based, state-changing routes need CSRF protection (token or strict SameSite + custom-header check). Pure Bearer-token APIs are exempt.
+
+## Login flow
+
+- **Rate limiting / lockout** on login, password reset, OTP verification — per-account and per-IP. Missing = Medium minimum.
+- **User enumeration:** identical errors and similar timing for "no such user" vs "wrong password"; registration and reset flows shouldn't reveal whether an email exists.
+- **Timing-safe comparison** for tokens, API keys, OTPs: `crypto.timingSafeEqual`, `hmac.compare_digest` — flag `==`/`===` on secret values.
+
+## Password reset
+
+- Token: ≥128 bits from a CSPRNG (not `Math.random`, not a timestamp/user-id hash), stored hashed, single-use, short expiry (≤1h).
+- Sessions invalidated on password change. Reset link host not built from the request's `Host` header (host-header injection → token theft).
+
+## Access control (authorization)
+
+- **Every route:** identify the authn middleware chain; list routes that skip it and confirm each is intentionally public. Watch for routers mounted before auth middleware and "temporary" debug endpoints.
+- **IDOR / object-level:** every fetch/update/delete by ID from the request must scope to the caller: `findOne({ id, userId: session.userId })` or an explicit ownership/tenant check after fetch. Hunt: `findById(req.params`, `get_object_or_404(Model, pk=` with no owner filter. Sequential integer IDs make it trivially exploitable — but UUIDs are NOT authorization.
+- **Function-level:** admin routes need a server-side role check, not just hidden UI. Role must come from the session/DB, never from the request body or a client-editable JWT claim.
+- **Privilege escalation via mass assignment:** can a profile-update endpoint set `role`/`isAdmin`? (see injection.md).
+- **Multi-tenancy:** tenant ID from the authenticated context, never from a request parameter; ideally enforced centrally (scoped query helpers, RLS) rather than per-query discipline.
+
+## OAuth / SSO
+
+- `redirect_uri` validated by exact match against a registration (not prefix/substring). `state` parameter required and verified (CSRF). PKCE for public clients.
+- Account linking by email: only trust `email_verified`; otherwise pre-registration account takeover.
+- ID token: verify signature, `aud`, `iss`, `nonce`.
+
+## API keys & machine auth
+
+- Stored hashed server-side (they're passwords). Timing-safe comparison. Scoped and revocable, prefixed (`sk_live_`) so leaks are greppable.
+- Internal service-to-service endpoints: confirm they're not reachable from the public edge with no auth ("the gateway handles it" — verify).

--- a/backend-security/skills/backend-security/references/deps.md
+++ b/backend-security/skills/backend-security/references/deps.md
@@ -1,0 +1,51 @@
+# Dependency & Supply-Chain Scan
+
+**Coverage anchors** — OWASP Top 10 2021: A06 Vulnerable & Outdated Components, A08 Software & Data Integrity Failures. ASVS 4.0: V14.2 (Dependency management). CWE: 1104, 1035, 937.
+
+## 1. Run the ecosystem's audit tool
+
+Use what the repo's lockfile implies. Run read-only audits; never auto-run `... audit fix` without approval.
+
+| Ecosystem | Command | Notes |
+|---|---|---|
+| npm | `npm audit` | `--omit=dev` to focus on runtime deps; JSON via `--json` |
+| pnpm | `pnpm audit` | |
+| yarn | `yarn npm audit` (berry) / `yarn audit` (v1) | |
+| Python | `pip-audit` | falls back: `pip install pip-audit`; or `osv-scanner` |
+| Go | `govulncheck ./...` | call-graph aware — its results are reachability-filtered already |
+| Java | `mvn org.owasp:dependency-check-maven:check` or Gradle equivalent | slow; osv-scanner is a faster first pass |
+| Ruby | `bundle audit` (bundler-audit) | |
+| PHP | `composer audit` | |
+| .NET | `dotnet list package --vulnerable --include-transitive` | |
+| Any / monorepo | `osv-scanner -r .` | good universal fallback if installed |
+
+If a tool isn't installed, say so and offer the install command — don't silently skip the step.
+
+## 2. Triage the results (don't just paste the output)
+
+For each reported vulnerability, assess and report:
+- **Reachability:** is the vulnerable function actually used? A prototype-pollution advisory in a build-time-only dep is Low; the same in the request path is High.
+- **Direct vs transitive:** direct → upgrade the dep; transitive → upgrade the parent, or use `overrides` (npm) / `resolutions` (yarn) / constraints as a stopgap and note it's a stopgap.
+- **Runtime vs dev dependency:** dev-only advisories rarely matter in production (but do matter in CI supply-chain terms).
+- Group by the fix action ("upgrade express to 4.19.2 clears 3 advisories") rather than listing CVEs one by one.
+
+## 3. Lockfile & manifest hygiene
+
+- Lockfile committed and in sync with the manifest (unlocked deps = non-reproducible, drift-prone builds).
+- No dependencies from raw URLs, `git+http://`, or personal forks without a pinned commit.
+- Version ranges on security-critical libs (auth, crypto, session, ORM): wide ranges (`*`, `>=`) are a flag.
+- Deprecated/unmaintained security-critical packages (e.g. abandoned auth middleware) — recommend maintained replacements.
+
+## 4. Supply-chain checks
+
+- **Install scripts (npm):** `postinstall` hooks are the main attack vector — for unfamiliar deps, check what their scripts do; recommend `--ignore-scripts` for CI installs where feasible.
+- **Typosquatting:** hand-typed package names close to popular ones; very new packages with few downloads pulled into production code.
+- **CI actions/plugins:** third-party GitHub Actions pinned to a SHA, not a movable tag, on repos holding secrets.
+- **Base images:** pinned tags or digests, not `latest`; if trivy/`docker scout` is available, offer an image scan — don't install scanners unprompted.
+
+## 5. Config files that ride along
+
+While in scan mode, also check (details in infra.md):
+- `Dockerfile` / `docker-compose.yml` — root user, baked secrets, `.dockerignore`
+- CI workflow files — secret exposure, fork-triggered workflows, unpinned actions
+- `.env*` — gitignored, never committed historically (`git log --all --oneline -- .env`), no `.env.production` with real values in the repo

--- a/backend-security/skills/backend-security/references/infra.md
+++ b/backend-security/skills/backend-security/references/infra.md
@@ -1,0 +1,66 @@
+# Secrets, Configuration & API Hardening
+
+**Coverage anchors** — OWASP Top 10 2021: A05 Security Misconfiguration, A02 Cryptographic Failures, A09 Security Logging & Monitoring Failures, A07 (rate limiting). ASVS 4.0: V7 (Error Handling & Logging), V8 (Data Protection), V9 (Communications), V14 (Configuration). CWE: 798, 16, 209, 532, 942, 693, 319, 311.
+
+## Hardcoded secrets
+
+Hunt in source, config, tests, and scripts:
+- Patterns: `AKIA[0-9A-Z]{16}` (AWS), `-----BEGIN (RSA |EC )?PRIVATE KEY`, `ghp_`/`gho_` (GitHub), `sk_live_`/`sk-` (Stripe/OpenAI), `xox[bp]-` (Slack), `eyJhbGci` (embedded JWTs), connection strings with credentials (`postgres://user:pass@`, `mongodb+srv://`), `password\s*[:=]\s*['"][^'"]+`, `api[_-]?key\s*[:=]`
+- `.env` files: confirm they're in `.gitignore` AND check history — `git log --all --oneline -- .env` (gitignore doesn't remove already-committed files). A secret ever committed is compromised: the fix is **rotate**, not just delete.
+- Secrets in test fixtures and example files pointing at real services; secrets logged at startup ("config dump" logs); secrets in client-delivered code (Next.js `NEXT_PUBLIC_`, Vite `VITE_` — these are public by design).
+
+## Dangerous configuration
+
+- Debug mode in production paths: Django `DEBUG=True`, Flask `debug=True` (Werkzeug debugger = RCE), Express `NODE_ENV` not production, GraphQL introspection + playground exposed in prod.
+- Default/weak credentials in docker-compose, seeds, or admin bootstrap code.
+- Admin/metrics/health endpoints (`/admin`, `/metrics`, `/actuator`, `/debug/pprof`, `/graphql`) exposed without auth. Spring Actuator and pprof are frequent real-world breaches.
+- TLS verification disabled: `rejectUnauthorized: false`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `verify=False` (requests), `InsecureSkipVerify: true` — flag every one, including in "internal" clients.
+
+## CORS
+
+- `Access-Control-Allow-Origin: *` combined with `Allow-Credentials: true` (browsers block it, but reflecting the request's `Origin` header with credentials is the same hole and does work). Hunt: origin callbacks that `return callback(null, true)` for any origin.
+- Origin validation by substring/`startsWith` (`https://myapp.com.evil.com` passes). Use exact-match allowlists.
+- `null` origin allowed (sandboxed iframes can send it).
+
+## Security headers & responses
+
+For APIs: `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, correct `Content-Type` on every response, `Cache-Control: no-store` on responses carrying tokens or personal data. For server-rendered HTML additionally: CSP, `frame-ancestors` (clickjacking). One-line wins: `helmet` (Express), `SecurityMiddleware` (Django).
+
+## Rate limiting & abuse
+
+- Required on: login, registration, password reset, OTP, anything sending email/SMS (cost + flooding), expensive queries, public write endpoints.
+- Keying: per-IP alone fails behind shared NATs and against botnets — sensitive flows need per-account too. If behind a proxy, the app must use the right client-IP header *and* trust only the proxy for it (spoofable `X-Forwarded-For` = rate-limit bypass).
+- Payload limits: JSON body size caps (`express.json({limit})`), pagination caps (`?limit=1000000`), GraphQL depth/complexity limits, regex on user input checked for ReDoS.
+
+## Error handling & logging
+
+- Stack traces, SQL errors, or framework debug pages returned to clients: information disclosure — return generic errors, log details server-side with a correlation ID.
+- Logs must not contain: passwords (watch "log the whole request body" middleware), tokens/API keys, full card numbers, session IDs. Check what the HTTP client/ORM logs at debug level in production.
+- Log injection: user input logged raw can forge lines via `\n` — encode or strip newlines in logged user data.
+- Missing audit logging on security events (login, failed login, permission change, data export) — worth a hardening note.
+
+## Sensitive data at rest
+
+- Regulated / high-value data — SSN, national ID, date of birth, financial account and routing numbers, health data, government IDs, auth tokens — stored **plaintext** in the DB is a Cryptographic Failure (OWASP A02). Flag columns/fields holding this data with no encryption or tokenization.
+- Encrypt with a vetted authenticated cipher (AES-GCM) using keys from a KMS/secret manager, or tokenize via a dedicated service — never a hardcoded key in the repo, and never a home-rolled scheme. Reused/static IVs and ECB mode are findings in themselves.
+- Data minimization first: if you don't need to store it (e.g. full card PAN — that's PCI scope), don't. Hash where you only ever need to compare, encrypt where you must read it back.
+- Hunt: model/schema definitions and `INSERT`/`update` calls writing `ssn`, `dob`, `taxId`, `bankAcc`, `routing`, `cardNumber`, `mrn` as raw strings; confirm an `encrypt(...)` / KMS call wraps them.
+
+## Dockerfile
+
+- Runs as root (no `USER` directive) — container escape blast radius.
+- Secrets via `ARG`/`ENV` at build time or `COPY .env` — baked into image layers forever. Use runtime env/secret mounts; check `.dockerignore` excludes `.env`, `.git`.
+- Unpinned base images (`FROM node:latest`); dev dependencies and build tools left in the final image (prefer multi-stage); overly broad `COPY . .` pulling in secrets.
+
+## CI/CD
+
+- Secrets echoed in logs; secrets available to workflows triggered by forks — `pull_request_target` with checkout of PR code is a known takeover pattern.
+- Third-party actions unpinned (`uses: some/action@v1` vs pinned SHA) — supply-chain risk on repos with secrets.
+- Deploy credentials scoped too broadly (CI having prod admin keys when it needs push-to-registry only).
+
+## Cloud & runtime (when config is visible in repo)
+
+- Public object-storage buckets holding user data; signed URLs with very long expiry.
+- Overly broad IAM in IaC (`"Action": "*"`, `"Resource": "*"`).
+- SSRF reachability to metadata endpoints (see injection.md) — on AWS, check IMDSv2 is enforced.
+- Databases/queues bound to public interfaces with password-only auth.

--- a/backend-security/skills/backend-security/references/injection.md
+++ b/backend-security/skills/backend-security/references/injection.md
@@ -1,0 +1,89 @@
+# Injection & Untrusted Input
+
+**Coverage anchors** — OWASP Top 10 2021: A03 Injection, A08 Software & Data Integrity (deserialization), A10 SSRF, A04 Insecure Design (mass assignment). ASVS 4.0: V5 (Validation, Sanitization & Encoding), V12 (File & Resources), V13 (API). CWE: 89, 78, 22, 79, 918, 502, 611, 1321.
+
+For each check: run the hunt patterns (adapt to the stack's idioms), then trace whether attacker-controlled data reaches the sink.
+
+## SQL injection
+
+Hunt for string-built queries and ORM escape hatches:
+- Concatenation/interpolation into query strings: `` query(`...${ ``, `"SELECT " +`, Python f-strings/`%`/`.format()` inside `execute(...)`
+- ORM raw escape hatches: Sequelize `literal()`/`query()`, Prisma `$queryRawUnsafe`/`$executeRawUnsafe`, Knex `.raw()`, TypeORM `.query()`, Django `.raw()`/`.extra()`, SQLAlchemy `text()` with interpolation, ActiveRecord `where("... #{...}")`
+- Dynamic ORDER BY / column names built from request params (parameterization can't cover identifiers — require an allowlist)
+
+**Fix:** parameterized queries / tagged templates (`$queryRaw` with template literal is safe; `$queryRawUnsafe` is not). Identifiers via explicit allowlist map.
+
+## NoSQL injection (MongoDB and friends)
+
+- Request objects passed directly into queries: `find(req.body)`, `findOne({ email: req.body.email, password: req.body.password })` — attacker sends `{"password": {"$gt": ""}}`
+- `$where`, `mapReduce`, or aggregation stages built from user input
+
+**Fix:** validate types at the boundary (must be string, not object); strip `$`-prefixed keys; use schema validation (zod/joi/mongoose strict).
+
+## Command injection
+
+- `child_process.exec`, `execSync`, `spawn(..., {shell: true})`; Python `os.system`, `subprocess` with `shell=True`; Ruby backticks/`system` with interpolation; Go `exec.Command("sh", "-c", ...)`
+- Also: arguments that become flags (`--output=...`) — argument injection even without a shell
+
+**Fix:** `execFile`/`spawn` with an args array and no shell; validate/allowlist arguments; prepend `--` where the tool supports it.
+
+## Path traversal
+
+- User input in `path.join`/`os.path.join`, `fs.readFile`, `sendFile`, `open()`, archive extraction (zip-slip)
+- `path.join(base, userInput)` is NOT safe — `../../` escapes. Check for: resolve then verify `resolved.startsWith(base + sep)`
+- Null bytes and URL-encoded traversal (`..%2f`) if input isn't decoded consistently
+
+**Fix:** resolve the full path and enforce it stays under the intended base directory; or map user input to an ID → filename lookup so no path math involves user data.
+
+## SSRF (server-side request forgery)
+
+- `fetch`/`axios`/`requests.get`/`http.Get` where any part of the URL (host, path, or full URL) comes from user input — webhooks, "import from URL", PDF/image fetchers, link previews
+- Check for: internal-network access (`localhost`, `10.x`, `172.16-31.x`, `192.168.x`), cloud metadata (`169.254.169.254`), redirects that bypass the check, DNS rebinding, non-HTTP schemes (`file://`, `gopher://`)
+
+**Fix:** allowlist of hosts where possible; otherwise resolve DNS and reject private/link-local ranges *after* redirects (validate per-hop, disable or re-validate redirects); enforce scheme `https`.
+
+## Insecure deserialization
+
+- Python `pickle.loads`, `yaml.load` without `SafeLoader`, `marshal`; Java `ObjectInputStream.readObject`, XMLDecoder; PHP `unserialize`; Node `node-serialize`, `serialize-javascript` misuse — on any data an attacker can influence (cookies, cache, queue messages, uploaded files)
+
+**Fix:** use JSON with schema validation; if a binary format is required, sign it (HMAC) and verify before deserializing.
+
+## XXE
+
+- XML parsers with external entities enabled: Java `DocumentBuilderFactory` without `disallow-doctype-decl`, Python `lxml` with `resolve_entities=True`, .NET `XmlReader` with `DtdProcessing.Parse`
+
+**Fix:** disable DTDs and external entity resolution; prefer `defusedxml` (Python).
+
+## Template injection (SSTI)
+
+- User input used as the *template* (not a variable): `render_template_string(userInput)`, Handlebars/EJS/Pug compile of user strings, Go `template.New().Parse(userInput)`
+- Email/notification systems that let users edit templates are the classic entry point
+
+**Fix:** user data goes into template variables only; if user-editable templates are a feature, use a logic-less sandboxed engine.
+
+## XSS from the backend
+
+- HTML responses concatenating user input; `res.send("<h1>" + name)`; disabled auto-escaping (`| safe`, `mark_safe`, `dangerouslySetInnerHTML` fed by API data, `{{{ }}}` in Handlebars)
+- APIs returning user content with wrong `Content-Type` (HTML sniffing) — JSON endpoints must send `application/json` and `X-Content-Type-Options: nosniff`
+- Reflected input in error pages and redirects (`Location` header injection via CRLF)
+
+## Open redirect & unvalidated redirects
+
+- User-controlled redirect targets: `res.redirect(req.query.url)`, `redirect(request.args.get('next'))`, `Location` set from a request param, post-login "return to" parameters, OAuth `redirect_uri`/`state` echoes.
+- Impact: phishing (attacker sends a link to your trusted domain that bounces to theirs), OAuth token/code theft when the redirect carries credentials, and a pivot for SSRF when the "redirect" is followed server-side (see SSRF above).
+- Hunt: `redirect(req.`, `res.redirect(`, `sendRedirect(`, `Location:` headers built from input, `?url=`/`?next=`/`?return=`/`?redirect=` parameters.
+
+**Fix:** redirect only to an allowlist of paths/hosts, or to relative paths you build (strip the scheme+host, reject anything starting with `//` or containing `:`). Never pass a raw user URL to a redirect. For OAuth, exact-match `redirect_uri` against registration.
+
+## File uploads
+
+Check the full chain:
+1. **Validation** — extension AND content type; never trust client `Content-Type`; allowlist, not denylist; beware double extensions (`shell.php.jpg`) and case tricks
+2. **Storage** — outside the web root or in object storage; generated filenames (never the user's — traversal + overwrite); size limits enforced server-side
+3. **Serving** — `Content-Disposition: attachment` or a separate domain for user content; correct Content-Type; no execution permissions
+4. **Processing** — image/document libraries run on untrusted files (historic RCEs: ImageMagick, ffmpeg); pin versions, consider sandboxing, strip metadata
+
+## Mass assignment
+
+- `Model.create(req.body)`, `user.update(params)`, `**request.json` spread into a model — attacker sets `role`, `isAdmin`, `price`, `verified`
+**Fix:** explicit field allowlist per endpoint (DTOs, serializers, `pick()` of named fields).

--- a/backend-security/skills/backend-security/references/nodejs.md
+++ b/backend-security/skills/backend-security/references/nodejs.md
@@ -1,0 +1,70 @@
+# Node.js / TypeScript Deep Checks
+
+**Coverage anchors** — OWASP Top 10 2021: A03 Injection, A01 Broken Access Control, A05 Misconfiguration, A06 Vulnerable Components, A08 Integrity Failures. ASVS 4.0: V5, V1 (Architecture/middleware), V14. CWE: 1321 (prototype pollution), 89, 78, 400 (ReDoS), 1104 (unmaintained deps).
+
+Read this in addition to the general references when the stack is Node. These are Node-specific bug classes and the exact APIs to hunt for.
+
+## Express/Fastify/Nest middleware ordering
+
+Order is the security model. Verify:
+1. Body parsing with a size limit (`express.json({ limit: '1mb' })`) — default-unlimited parsers enable memory DoS.
+2. Auth middleware registered **before** the routers it protects — hunt for `app.use('/api', router)` lines that appear above `app.use(authMiddleware)`, and routers that mount their own paths bypassing the guarded prefix.
+3. Error handler registered **last**, and it must not leak `err.stack` to the client in production.
+4. `helmet()` (or manual headers) present; `app.set('trust proxy', ...)` configured correctly if behind a proxy — wrong trust-proxy makes `req.ip` spoofable, breaking IP rate limits.
+5. Nest: `@UseGuards` present at controller or global scope; hunt for controllers/handlers missing guards, and `@Public()`-style decorators on things that shouldn't be public.
+
+## Prototype pollution
+
+Attacker sends `{"__proto__": {"isAdmin": true}}` (or `constructor.prototype`) into a deep merge, polluting every object.
+- Hunt sinks: `lodash.merge`/`mergeWith`/`defaultsDeep`, `deepmerge`, hand-rolled recursive merge/extend, `Object.assign(target, ...userInput)` where target is reused, setting keys by user-supplied path (`set(obj, req.body.path, value)`).
+- Confirm: does user input reach a deep merge? Is lodash patched (< 4.17.12 vulnerable)?
+- **Fix:** validate schemas before merging (zod strips unknown keys), reject `__proto__`/`constructor`/`prototype` keys, use `Object.create(null)` for dictionaries, or `structuredClone` + explicit field copying.
+
+## ORM/DB escape hatches
+
+- **Prisma:** `$queryRawUnsafe`/`$executeRawUnsafe` with interpolation = SQLi. `$queryRaw` with a tagged template literal is parameterized and safe — the distinction is exactly the backticks.
+- **Sequelize:** `sequelize.query()` with string interpolation (use `replacements`/`bind`), `Sequelize.literal()` with user input, and legacy operator-injection via user-supplied objects in `where`.
+- **Knex:** `.raw()`/`whereRaw()` with interpolation (use `?` bindings).
+- **TypeORM:** `.query()` with concatenation; QueryBuilder `.where("id = " + id)` instead of parameter objects.
+- **Mongoose/Mongo:** `$where` clauses; query objects built from `req.body`/`req.query` (operator injection — see injection.md); enable `sanitizeFilter` or strip `$` keys.
+
+## Code execution & processes
+
+- `eval()`, `new Function()`, `vm.runInContext` with any user input — the `vm` module is NOT a security sandbox.
+- `child_process.exec`/`execSync` build a shell string → prefer `execFile`/`spawn` with args array; flag `spawn(..., { shell: true })`.
+- Dynamic `require()`/`import()` from user-influenced paths.
+
+## Path & static file handling
+
+- `path.join(base, req.params.file)` traverses — see injection.md for the resolve-and-verify fix.
+- `res.sendFile(name)` needs the `root` option (it enforces containment); without it, absolute paths and traversal work.
+- `express.static` with `dotfiles: 'allow'` or pointed at a directory containing `.env`/`.git`.
+
+## JWT (jsonwebtoken specifics)
+
+- `jwt.verify(token, secret, { algorithms: ['HS256'] })` — the `algorithms` allowlist must be present; historic versions accepted attacker-chosen algorithms.
+- `jwt.decode()` performs **no verification** — any trust decision after bare decode is an auth bypass.
+- Verify which key type matches the algorithm (public key + HS256 = confusion attack on old versions).
+
+## Timing & crypto
+
+- Compare secrets with `crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))` (equal lengths required — hash both first), never `===`.
+- Tokens from `crypto.randomBytes`/`crypto.randomUUID`, never `Math.random()`.
+- Hunt: `Math.random().toString(36)` used for anything security-relevant.
+
+## ReDoS
+
+- User input tested against regexes with nested quantifiers (`(a+)+`, `(\w+\s?)*`) blocks the single-threaded event loop — one request can take down the process.
+- Validation libraries with user-supplied patterns; `validator.js`/custom email regexes are common offenders.
+
+## npm ecosystem
+
+- `npm audit` (see deps.md); lockfile committed; no `git+http`/tarball-URL dependencies.
+- New/unfamiliar packages: check publish date, downloads, and `postinstall` scripts (`npm pkg get scripts` per dep, or `--ignore-scripts` in CI installs) — install-time scripts are the main npm supply-chain vector.
+- Typosquatting on hand-typed installs.
+
+## Environment & TypeScript boundary
+
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` anywhere (env files, Dockerfiles, CI) disables TLS verification process-wide.
+- TypeScript types are compile-time only: `req.body as CreateUserDto` validates nothing. Every external boundary (HTTP body/params/query, queue messages, webhooks) needs runtime validation (zod/joi/class-validator with `whitelist: true`). Hunt: handlers reading `req.body.x` with no schema parse in the chain.
+- `console.log` of full request/response objects in production paths (token/PII leakage into logs).

--- a/backend-security/skills/backend-security/references/roadmap.md
+++ b/backend-security/skills/backend-security/references/roadmap.md
@@ -1,0 +1,76 @@
+# Harden Roadmap: Zero → Hardened Backend
+
+Use this in **Harden mode** — when the user wants to take a backend with little or no security and build it up to a defensible baseline. Work the phases in order: each phase depends on the previous one being real, not aspirational. Every phase has **exit criteria** mapped to the OWASP Application Security Verification Standard (ASVS 4.0), so "done" is measurable rather than a vibe.
+
+Realistic target: completing all six phases gets the **application layer** to roughly **ASVS Level 1 and much of Level 2**. That is a strong baseline — better than most early-stage products — but it is not the whole of "enterprise grade." See `../SKILL.md` → Scope & limits for what lives outside this roadmap (infra ops, monitoring/IR, compliance certification, pentesting).
+
+How to run a phase: assess current state against the checklist, report the gaps ranked by the severity rubric, propose fixes, and apply them only after the user approves (same rules as audit mode). Don't advance to the next phase until the current phase's exit criteria hold.
+
+---
+
+## Phase 1 — Foundations & input validation
+*Goal: nothing untrusted reaches a dangerous sink unvalidated; the app fails safe.*
+
+- Every external input boundary (HTTP body/query/params, headers, webhooks, queue messages, uploaded files) has runtime schema validation — types, ranges, allowlists — not just compile-time types. See `injection.md` and `nodejs.md` (the TypeScript boundary note).
+- No injection sinks reachable from user input: parameterized DB queries, no `eval`/dynamic code, `execFile` over shell strings, path traversal defended. Sweep every class in `injection.md`.
+- Central error handler returns generic messages to clients; stack traces and internal errors go to server logs only.
+- Body-size limits and basic payload caps set (pagination limits, JSON size) so a single request can't exhaust memory.
+
+**Exit criteria (ASVS V5 Validation/Sanitization/Encoding, V7 Error Handling):** no unparameterized queries; no code-eval of input; all inputs validated at the boundary; errors don't leak internals.
+
+## Phase 2 — Authentication
+*Goal: identity is established securely and can't be trivially bypassed or brute-forced.*
+
+- Passwords stored with bcrypt/argon2id/scrypt; verification via the library's constant-time compare. No plaintext, no fast hashes. (`auth.md`)
+- Password policy: minimum length (≥8, prefer ≥12), reject known-breached/common passwords; no arbitrary composition rules that push users to weak patterns.
+- Session management: server-side sessions or properly signed tokens; session ID regenerated on login (anti-fixation) and invalidated on logout and password change.
+- Login, registration, password-reset, and OTP endpoints are rate-limited and lock out / back off on repeated failure. Identical errors and similar timing for unknown-user vs wrong-password (no enumeration).
+- Password reset uses a CSPRNG token, stored hashed, single-use, short-lived; reset host not derived from the request `Host` header.
+
+**Exit criteria (ASVS V2 Authentication, V3 Session Management):** strong hashing verified; sessions regenerate and expire; brute-force controls on all credential endpoints; no user enumeration.
+
+## Phase 3 — Authorization & multi-tenancy
+*Goal: authenticated users can act only on what they're entitled to.*
+
+- Every route past the auth boundary has an explicit authorization decision; the list of intentionally public routes is reviewed and confirmed.
+- Object-level authorization (no IDOR): every fetch/update/delete by an ID from the request is scoped to the caller (`{ id, ownerId: session.userId }` or an explicit ownership/tenant check after load). UUIDs are not authorization. (`auth.md`)
+- Function-level authorization: admin/privileged routes check a server-side role that comes from the session/DB, never from the request body or a client-editable token claim.
+- No privilege escalation via mass assignment: update endpoints use explicit field allowlists so `role`/`isAdmin`/`price` can't be set by the client. (`injection.md`)
+- Multi-tenant apps derive tenant scope from the authenticated context, enforced centrally (scoped query helpers / row-level security), not per-query discipline.
+
+**Exit criteria (ASVS V4 Access Control):** every ID-taking route ownership-checked; privileged routes role-checked server-side; no mass-assignment path to authorization fields.
+
+## Phase 4 — Secrets & data protection
+*Goal: secrets aren't in the repo, sensitive data is protected in transit and at rest.*
+
+- No secrets in source, config, history, or client bundles; secrets come from env/secret manager. Anything ever committed is rotated, not just deleted. (`infra.md`)
+- TLS everywhere: HTTPS enforced (HSTS), no disabled certificate verification anywhere in the codebase, including "internal" clients.
+- Sensitive data at rest (PII such as SSN/DOB, financial data, tokens) is encrypted or tokenized; secrets and keys are managed, not hardcoded.
+- Cookies carrying auth: `HttpOnly`, `Secure`, `SameSite`; responses with tokens/PII set `Cache-Control: no-store`. Logs scrubbed of passwords, tokens, PII. (`auth.md`, `infra.md`)
+
+**Exit criteria (ASVS V6 Stored Cryptography, V8 Data Protection, V9 Communications):** no committed secrets; TLS enforced with verification on; sensitive data encrypted at rest; sensitive data kept out of logs.
+
+## Phase 5 — Abuse resistance & configuration hardening
+*Goal: the app resists automated abuse and ships with a locked-down configuration.*
+
+- Rate limiting and payload/complexity limits on all expensive and abusable endpoints (auth, search, email/SMS senders, public writes, GraphQL depth). Correct client-IP handling behind proxies so limits can't be spoofed. (`infra.md`)
+- Security headers set (helmet or equivalent): `nosniff`, HSTS, and CSP/`frame-ancestors` for any HTML. CORS uses an exact-match allowlist, never reflect-origin-with-credentials.
+- Production config hardened: debug modes off, framework debuggers disabled, admin/metrics/health/introspection endpoints authenticated or not exposed, default credentials removed.
+- ReDoS-safe input validation; dependency and container config hardened per `deps.md` (audit clean of known-reachable criticals, images non-root, no baked secrets).
+
+**Exit criteria (ASVS V13 API/Web Service, V14 Configuration):** rate limits on abusable endpoints; security headers + strict CORS; no debug/admin surface exposed in prod; dependency audit triaged.
+
+## Phase 6 — Observability & incident readiness
+*Goal: security-relevant events are recorded, and there's a plan for when something goes wrong.*
+
+- Security event logging: authentication (success/failure), authorization denials, privilege and password changes, data exports — with correlation IDs, no sensitive values, tamper-resistant storage.
+- Monitoring/alerting on abuse signals (spikes in auth failures, 403s, error rates) — at least wired to a destination, even if basic.
+- A written, minimal incident-response path: how a report is received, who rotates credentials, how users are notified. Dependency-update / patch cadence defined.
+- Backups exist and restore is tested; secret-rotation procedure documented.
+
+**Exit criteria (ASVS V7 Logging, plus operational readiness):** security events logged safely; an alerting destination exists; a documented IR and patch process is in place. *(This phase reaches into operations — the roadmap gets you to readiness; running it 24/7 is an ops function beyond the skill.)*
+
+---
+
+## Reporting a Harden engagement
+Produce a phase-by-phase status: for each phase, `Met / Partial / Not met`, the specific gaps (with `file:line` and severity), and the prioritized fixes. Lead with the phase the backend is currently stuck at — that's where the next work goes. Restate the Scope & limits boundary so "all six phases met" is never mistaken for "certified enterprise-secure."

--- a/marketplace.json
+++ b/marketplace.json
@@ -171,6 +171,13 @@
       "description": "Analyze coding patterns and get personalized learning resources",
       "author": "Composio",
       "tags": ["productivity", "learning", "growth", "analytics"]
+    },
+    {
+      "name": "backend-security",
+      "category": "security",
+      "description": "Full-codebase backend security audits, dependency/config scanning, secure-coding guidance, and a phased zero-to-hardened roadmap. OWASP Top 10 / ASVS anchored, benchmarked against NodeGoat",
+      "author": "Ghostfreak-cypher",
+      "tags": ["security", "owasp", "asvs", "audit", "appsec", "backend"]
     }
   ],
   "categories": [


### PR DESCRIPTION
## What this adds

A new **`backend-security`** plugin under the **security** category — a defensive backend security toolkit for Claude Code.

### What it does
- **Audit** — full-codebase security review mapping untrusted input → dangerous sinks (SQL/NoSQL/command injection, SSRF, IDOR, auth, secrets, deserialization, uploads, and more), with a severity-ranked report and ready-to-apply fixes.
- **Scan** — dependency & config/supply-chain scanning (delegates to `npm audit` / `pip-audit` / `osv-scanner` / `govulncheck`, so CVE data stays current).
- **Guide** — secure-coding guidance while writing auth, endpoints, queries, or uploads.
- **Harden** — a phased zero→hardened roadmap with OWASP ASVS 4.0 exit criteria.

### Details
- Stack-aware (auto-detects Node/Python/Go/Java/PHP/Ruby/.NET) with a deep-dive for **Node.js/TypeScript**.
- Every reference file is anchored to **OWASP Top 10 2021 / ASVS 4.0 / CWE** so coverage is auditable.
- **Honest about limits**: it states in-product that it is not a substitute for a professional pentest or compliance program.
- **Benchmarked** against OWASP NodeGoat (12/12 documented vulnerability classes after one fix-and-rerun loop, 0 false positives) — with an explicit training-data-contamination caveat.

Follows the existing marketplace conventions: plugin vendored at repo root with `.claude-plugin/plugin.json` + `skills/`, and a single catalog entry appended to `marketplace.json` (`security` category). Both JSON files validated.

Source & full docs: https://github.com/Ghostfreak-cypher/backend-security-skill · MIT licensed.