### PR TITLE
Add praetor (external plugin: delegation with a binding judge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [praetor](https://github.com/luoxianzi/praetor) - Delegate grunt work from Claude to the Codex CLI behind a binding independent judge — acceptance criteria frozen in git before the executor runs, fresh-context PASS/FAIL that cannot be overridden, Legion Mode for 2–5 parallel workers in git worktrees with an integration judge. Zero config.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds **praetor** — what sets it apart from the first-party codex bridge: a binding, independent, fresh-context judge. Acceptance criteria are frozen in git *before* the executor runs, and the judge — which never saw the planning conversation — returns a PASS/FAIL the planner cannot override. Legion Mode runs 2–5 parallel Codex workers in isolated git worktrees behind a mandatory integration judge (2.84× measured on a real 3-lane run). Zero-config; the README benchmark table includes its own failures on purpose. MIT.

Repo: https://github.com/luoxianzi/praetor · Why-a-judge write-up: https://github.com/luoxianzi/praetor/blob/main/docs/WHY-A-JUDGE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)