### PR TITLE
Add threadctx to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [threadctx](https://github.com/threadctx-dev/threadctx-mcp) - Shared team memory for AI coding agents. Decisions, fixes, and gotchas persist per repo and are shared across Claude Code, Cursor, and any MCP client — plus a team-memory skill teaching agents to use it well. ([Website](https://threadctx.dev))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [threadctx](https://github.com/threadctx-dev/threadctx-mcp) — shared team memory for AI coding agents. Installable as a Claude Code plugin (`claude plugin marketplace add threadctx-dev/threadctx-mcp`): wires the MCP server (decisions/fixes/gotchas persist per repo, shared across the team) and ships a team-memory skill. Local-first, MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)