### PR TITLE
Add claude-railguards to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [claude-railguards](https://github.com/lmcdo/claude-railguards) - Deterministic pre-write guardrails for coding agents. A PreToolUse hook blocks edits that would duplicate existing code, a pre-implementation gate enforces investigation before database changes, and a QA-report contract gates risky pushes.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds **claude-railguards** under Code Quality & Testing.

Deterministic pre-write guardrails for coding agents: a PreToolUse hook blocks edits that would duplicate existing code, a pre-implementation gate enforces investigation before database changes, and a QA-report contract gates risky pushes. Distributed as its own Claude Code plugin marketplace (MIT).

- Addresses a real use case: stops an agent silently re-implementing capability that already exists.
- Doesn't duplicate existing entries: block-*before*-write prior-art guarding isn't covered by the current list.
- Uses an external link to its own marketplace repo, consistent with other externally-linked entries.