### PR TITLE
Add TheBoardroom to Business & Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
   - [Companion & Personality](#companion--personality)
+  - [Business & Strategy](#business--strategy)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
 - [Resources](#resources)
@@ -157,6 +158,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.
+
+### Business & Strategy
+
+- [TheBoardroom](https://github.com/kevinmhorvath/theboardroom) - An AI executive board of directors. Five sub-agent personas (CEO, CFO, COO, CLO, CISO) independently review a business idea, debate each other, and deliver an integrated board memo with a Go/No-Go recommendation. Built for pressure-testing initiatives before a real board meeting.
 
 ### Image Generation
 


### PR DESCRIPTION
## What

Adds [TheBoardroom](https://github.com/kevinmhorvath/theboardroom) under a new **Business & Strategy** category.

## Why

TheBoardroom vets business ideas through five executive sub-agent personas (CEO, CFO, COO, CLO, CISO) that review independently, debate each other, and produce an integrated board memo ending in a Go / No-Go / Conditional-Go decision. No existing category covers business decision-making plugins — happy to move it elsewhere if maintainers prefer.

## Checklist

- Real use case: pressure-testing initiatives, M&A targets, and new offerings before presenting to a real board
- No duplicate: no existing entry covers executive/board-style idea vetting
- Standard plugin structure: `.claude-plugin/plugin.json` + `skills/theboardroom/SKILL.md`, MIT licensed
- Tested: installable via `claude plugin marketplace add kevinmhorvath/theboardroom && claude plugin install theboardroom@kevinmhorvath`; skill triggering benchmarked at 100% on a 20-query test