### PR TITLE
Add taleseal to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [taleseal](https://github.com/Taleseal/taleseal) - Seals a Claude Code run as a shareable "tale" — a narrative page (trigger, data consumed, decisions taken and set aside, outcome) at one short link anyone can read without an account. Preview and redaction report before publish.
+
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
Adds [taleseal](https://github.com/Taleseal/taleseal) under Developer Productivity. It's a Claude Code plugin that seals a run into a shareable "tale" — a narrative page (trigger, data consumed, decisions taken and set aside, outcome) at one short link anyone can read without an account. You always see a preview with a redaction report before anything publishes. MIT, on npm as `taleseal`; installable via `/plugin marketplace add Taleseal/taleseal`.

Matched the existing single-line + description format.