### PR TITLE
Add aSPARK — gated agile delivery process plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [aSPARK](https://github.com/a-lottes/aSPARK) - Turns Claude Code into a gated delivery process with a full AI product team (PO, Designer, EM, Reviewer, QA, Release). Every feature must clear a quality gate before advancing, including hands-on QA in a real browser. MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds aSPARK to the list.

aSPARK turns Claude Code into a gated delivery process with an AI product team. Every feature moves through five phases (Specify → Plan → Act → Review → Keep) and can only advance when the previous phase's quality gate is green. Includes real-browser QA that verifies each acceptance criterion before release, and keeps all decision artifacts inside the project as a reviewable trail.

- Repo: https://github.com/a-lottes/aSPARK
- License: MIT
- Install: `/plugin marketplace add a-lottes/aSPARK` then `/plugin install aspark@aspark`

I've matched the existing entry format and placed it in the **Developer Productivity** section. Happy to adjust categorization.
