### PR TITLE
Add craftsman (engineering-discipline plugin) to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [craftsman](https://github.com/bufferBrew/craftsman) - Engineering-discipline toolkit: minimal-diff coding, root-cause debugging with recurring-bug detection, and honest completion reports. Ten agents, seven skills, an orchestrator, and cross-platform hooks.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
## What

Adds [craftsman](https://github.com/bufferBrew/craftsman) to the **Code Quality & Testing** section.

## Why it fits

craftsman is a Claude Code plugin that makes engineering discipline the default:

- **Minimal-diff coding** — the smallest change that solves the problem; anything beyond the request needs explicit OK.
- **Root-cause debugging** — no fix without an established root cause, plus recurring-bug detection via a knowledge graph and a `KNOWN_ISSUES.md` workflow.
- **Honest completion** — every nontrivial task ends with a Verified / Assumed / Not covered status block.
- Ten agents (planner, coder, reviewer, tester, security, release-prep, …), seven skills, two slash commands (`/craftsman:init`, `/craftsman:quick`), and a cross-platform (Windows + Unix) hook system.

Install:
```
claude plugin marketplace add bufferBrew/craftsman
claude plugin install craftsman@craftsman
```

MIT licensed, CI-validated (manifest + hooks validation workflow). Follows the same external-link entry style as AgentLint, security-sweep, and context-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)