### PR TITLE
Add cc-delegate to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [cc-delegate](https://github.com/EtienneLescot/cc-delegate) - Delegate a whole dev task from your Opus supervisor to a cheaper worker model (any litellm provider). Isolated git worktree per task, rubric-graded "done", one clean diff to review — async, with mid-run steering and budget caps.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **cc-delegate** to the Developer Productivity section, following the same externally-hosted link pattern as `codebase-graph`, `agntk`, and `backlog`.

[cc-delegate](https://github.com/EtienneLescot/cc-delegate) is a Claude Code plugin (MCP) that delegates a *whole* dev task from an Opus supervisor to a cheaper worker model on any litellm-routable provider (100+). Each task runs in an isolated git worktree, completion is graded against your `definition_of_done`/`test_command` rather than the model's own say-so, and you review one clean diff. Async supervision with mid-run steering, budget caps, and an enforced `git push`/`merge`/`rebase` guard.

MIT licensed. Thanks for maintaining the list!