### PR TITLE
Add msp-claude-plugins to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [msp-claude-plugins](https://github.com/wyre-technology/msp-claude-plugins) - Community-driven marketplace for Managed Service Providers, 70+ plugins across PSA, RMM, security, documentation, and accounting (Autotask, HaloPSA, Datto RMM, IT Glue, Huntress, and more), plus cross-vendor industry workflow packs (ops, security, finance, compliance, sales, DevOps, cloud infra) that compose whatever tools an org has connected instead of hardcoding one vendor's API.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds [wyre-technology/msp-claude-plugins](https://github.com/wyre-technology/msp-claude-plugins) under Integrations, alongside connect-apps and kaggle-skill.

It's a community-driven Claude Code plugin marketplace for MSPs (Managed Service Providers): 70+ plugins covering PSA/RMM/security/documentation/accounting tools (Autotask, HaloPSA, Datto RMM, IT Glue, Huntress, and more), plus 7 cross-vendor industry workflow packs (ops, security, finance, compliance, sales, DevOps, cloud infra) that compose whatever tools an org has connected rather than hardcoding a single vendor's API.

- Real use case: MSPs managing dozens of disconnected PSA/RMM/security tools, addressed by giving Claude a unified, discoverable tool surface.
- Doesn't duplicate anything currently listed — no existing entry targets the MSP/PSA/RMM vertical.
- Follows the official Claude Code plugin-marketplace schema (`.claude-plugin/marketplace.json`), CI-validated on every PR.