### PR TITLE
Add roadmapsmith to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [roadmapsmith](https://github.com/PapiScholz/roadmapsmith) - Keep ROADMAP.md in sync with the codebase. `/roadmap-init` scans a repo and generates a roadmap; `/roadmap-update` proposes marking tasks complete when supporting evidence is detected in the code. Works with Claude Code, Codex, and any SKILL.md host.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds `roadmapsmith` to Developer Productivity.

- Repo: https://github.com/PapiScholz/roadmapsmith
- npm: https://www.npmjs.com/package/roadmapsmith
- skills.sh: https://skills.sh/PapiScholz/roadmapsmith
- Also listed in: hashgraph-online/awesome-codex-plugins, rohitg00/awesome-claude-code-toolkit (pending)

A SKILL.md-compatible skill for Claude Code, Codex, and any host reading SKILL.md. Two slash commands: `/roadmap-init` scans a repo and generates ROADMAP.md; `/roadmap-update` proposes marking tasks complete only when supporting evidence is detected in the code. MIT license.