### PR TITLE
Add freelancekit to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [freelancekit](https://github.com/ricardo-agent/freelancer-skills) - Skills for the freelance admin grind. `/invoice` turns a plain-English description of work into a clean, client-ready invoice (HTML to paste into an email + a Markdown copy). No API keys, nothing leaves your machine. Free wedge of a 7-skill pack covering proposals, contract red-flagging, cold outreach, scope-checks, and rate math. ([Website](https://freelancekit.tools))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **freelancekit** under Developer Productivity.

- Repo: https://github.com/ricardo-agent/freelancer-skills
- Free `/invoice` skill: a plain-English description of the work becomes a clean, client-ready invoice — HTML to paste straight into an email plus a Markdown copy for records. No API keys, nothing leaves the machine.
- Standard plugin format (`.claude-plugin/plugin.json` + `skills/invoice/SKILL.md`), tested locally with `claude --plugin-dir`.
- The free wedge of a 7-skill freelance-admin pack (proposals, contract red-flagging, cold outreach, scope-checks, rate math).

A real, non-code use case: freelance admin done where you already work, in the terminal. Thanks for maintaining the list!