### PR TITLE
Add notes-janitor (Apple Notes audit/re-sort skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [notes-janitor](https://github.com/olevasyliev/notes-janitor) - Audit, digest, and reorganize your Apple Notes archive locally on macOS. Finds forgotten ideas and notes with leaked secrets, re-sorts years of notes with a rollback log.
 
 ### Companion & Personality
 


### PR DESCRIPTION
notes-janitor is a Claude Code skill that audits and reorganizes a macOS Apple Notes archive locally: it surfaces forgotten ideas, flags notes containing leaked secrets, and re-sorts years of accumulated notes with a rollback log so changes can be undone.

Adding it under Developer Productivity since it fits alongside the other local-first personal/dev productivity tools already listed there.