### PR TITLE
Add Hivemind under Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Hivemind](https://github.com/activeloopai/hivemind) - Captures coding-agent sessions via lifecycle hooks and distills the traces into SKILL.md files that Claude Code loads natively, so fixes stop getting rediscovered. Team workspaces share skills across engineers. Also works with Codex, Cursor, and OpenClaw. ([Website](https://deeplake.ai/hivemind))
 
 ### Companion & Personality
 


### PR DESCRIPTION
This adds Hivemind (activeloopai/hivemind, ~1.5k stars, open source) to the Developer Productivity section. It captures Claude Code sessions through lifecycle hooks, then a background worker turns the traces into SKILL.md files that Claude Code picks up natively, and team workspaces share those skills so one engineer's lesson reaches the whole team. Full disclosure, I work at Deeplake, which builds Hivemind. Happy to move it to a different section if you prefer.