### PR TITLE
Add trigger-tree documentation telemetry plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Documentation & Security
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
+- [trigger-tree](https://github.com/Hedde/trigger_tree) - Local documentation-discovery telemetry for Claude Code with a live dashboard, heat maps, health diagnostics, and evidence-backed router fixes. Runs locally without model tokens or network calls.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 


### PR DESCRIPTION
<img width="254" height="254" alt="logo-tt" src="https://github.com/user-attachments/assets/65754f0a-4281-4171-abaa-908c993a4367" />

Adds [trigger-tree](https://github.com/Hedde/trigger_tree) under **Documentation & Security**.

trigger-tree records which documentation Claude Code actually discovers during normal repository work, then presents that local event data as a live dashboard, heat/cold maps, health diagnostics, and evidence-backed router suggestions. It uses no model tokens or network calls at runtime.

The plugin is released under MIT, validates with `claude plugin validate`, supports Python 3.10–3.13 and Linux/macOS/Windows, and has a green multi-platform CI/security pipeline with 100% Python coverage.

Validation for this change:
- Exactly one repository link added
- `git diff --check` passes