### PR TITLE
Add ghost-in-the-droid — give Claude Code a real Android/iOS phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [ghost-in-the-droid](https://github.com/ghost-in-the-droid/android-agent) - Give Claude Code (or any MCP client) a real Android or iPhone as its body. 62 MCP tools: tap, swipe, screenshot, screen-tree reading, app launch, on-device inference (llama.cpp/MediaPipe/MLX), Docker+KVM emulator pools. `pip install ghost-in-the-droid` ([Website](https://ghostinthedroid.com))
+
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
## What this adds

**Ghost in the Droid** under **Developer Productivity** — an open-source MCP server that gives Claude Code (or any MCP client) a real Android or iPhone as its body.

- **62 MCP tools:** tap, swipe, screenshot, screen-tree reading, app launch, on-device inference (llama.cpp, MediaPipe, MLX), Docker+KVM emulator pools
- Works with Claude Code, Cursor, LangChain, LlamaIndex, and any MCP client
- **Install:** `pip install ghost-in-the-droid`
- **Repo:** https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.3.0
- **Site:** https://ghostinthedroid.com
- **License:** MIT | Python 🐍

Perfect for the Claude Code audience — one pip install and Claude can tap, swipe, and screenshot a real phone.