### PR TITLE
Add ai-science-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [ai-science-toolkit](https://github.com/dgilford/ai-science-toolkit) - One-line-install plugin bundling 18 science-workflow skills and 4 domain-expert reviewer agents (climate attribution, statistics, meteorology, science communication).
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds ai-science-toolkit — a bundle of Claude Code skills and domain-expert reviewer subagents for scientific research (climate attribution, statistics, meteorology, science communication), installable as a plugin. MIT-licensed, v1.0.0 with a Zenodo DOI.