### PR TITLE
Add frugal (cost-optimised model router) to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [frugal](https://github.com/ThomasLangbroek/frugal) - Cost-optimised agent router for Claude Code. Routes each sub-task to the cheapest capable model (deterministic command, then Haiku, Sonnet, the main model, and Fable as an escalation ceiling) and escalates only on verified failure. Ships as a routing skill, five agent definitions, and two fail-open hooks, with per-run cost metrics.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds **[frugal](https://github.com/ThomasLangbroek/frugal)** under **DevOps & Performance**, next to the other cost tools (`aws-cost-saver`, `Manifest`).

frugal is a Claude Code plugin that turns the main model into a router: every sub-task goes to the cheapest tier that can do it (a deterministic shell command, then Haiku, then Sonnet, then the main model, with Fable as an escalation ceiling), and it escalates only when a real check fails. No runtime, no API keys, no network calls. MIT, CI and CodeQL green.

Listed as an external-repo link, consistent with existing entries in this section (`aws-cost-saver`, `Manifest`, etc.) rather than a vendored folder, since it is maintained in its own repo. Happy to vendor the plugin folder instead if that is the preferred format.

- Genuine use case: reduces model spend on non-reasoning work.
- Not a duplicate: no existing entry does cost-based model routing.
