### PR TITLE
Add UIZZE Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [UIZZE](https://github.com/samuelbushi/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate.
 
 ### Git & Version Control
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
-- [UIZZE](https://github.com/uizze/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate. [uizze.com](https://uizze.com)
+- [UIZZE](https://github.com/uizze/uizze) - Stop generic UI before it ships with a free anti-ui-slop skill and UI Slop Gate for Claude Code; optional MCP access adds 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.
 
 ### Git & Version Control
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
-- [UIZZE](https://github.com/samuelbushi/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate. [uizze.com](https://uizze.com)
+- [UIZZE](https://github.com/uizze/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate. [uizze.com](https://uizze.com)
 
 ### Git & Version Control
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
-- [UIZZE](https://github.com/samuelbushi/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate.
+- [UIZZE](https://github.com/samuelbushi/uizze) - Grounds Claude Code in 800,000+ real web and iOS screens, locks a product-specific design contract, and blocks generic UI at a rendered finish gate. [uizze.com](https://uizze.com)
 
 ### Git & Version Control
 


### PR DESCRIPTION
Adds the public UIZZE Claude Code plugin to Frontend & Design.\n\nUIZZE is a maintained MIT-licensed plugin and Agent Skill. The free anti-ui-slop skill and UI Slop Gate stop generic UI; optional MCP access adds live research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.\n\n- Canonical repository: https://github.com/uizze/uizze\n- Product/docs: https://uizze.com/ai-ui-slop\n- Plugin manifest: .claude-plugin/plugin.json\n- HOL Plugin Scanner: https://github.com/uizze/uizze/actions/workflows/hol-plugin-scanner.yml\n\nThis PR changes one catalog line only.