### PR TITLE
Add Agentlas OS to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) with a Claude Code marketplace plugin for building, routing, and running specialist agent teams with memory, permission, and verification gates.
 
 ### DevOps & Performance
 


### PR DESCRIPTION
## Summary

- Add Agentlas OS to Backend & Architecture.
- Describe its public Claude Code marketplace plugin and local-first specialist-agent orchestration.
- Match the existing external plugin entry format.

## Verification

- The public repository documents the Claude Code marketplace add and plugin install commands.
- The repository link resolves.
- `git diff --check` passes.

Disclosure: I am submitting this on behalf of Agentlas.
