### PR TITLE
Add wiki-to-graph plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
+- [wiki-to-graph](https://github.com/MangroveTechnologies/wiki-to-graph) - Turn an LLM wiki (a folder of interlinked markdown pages) into a typed, queryable knowledge graph. Build, validate, analyze, query, update, and view it in a browser. Python 3, standard library only.
 
 ### Developer Productivity
 


### PR DESCRIPTION
Adds **wiki-to-graph** under *Documentation & Security*.

Turns an LLM wiki (a folder of interlinked markdown pages, the Karpathy "LLM wiki" pattern) into a typed, queryable knowledge graph — build, validate, analyze (PageRank/communities), query (BFS/DFS/shortest-path with edge- and node-type filters), update, and an offline HTML viewer. Python 3, standard library only (also a Claude plugin + skill).

Repo: https://github.com/MangroveTechnologies/wiki-to-graph
Entry follows the existing one-line, no-emoji, description (not sales-pitch) style.