### PR TITLE
Add consilium-principis (Developer Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [consilium-principis](https://github.com/ilyautov/consilium-principis) - A board of AI advisor personas grounded in public-domain texts with a fail-closed fidelity contour: every quote is verified word-for-word against its source by code, or the advisor abstains. Local MCP server, no keys.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **consilium-principis** — a Claude Code plugin + local (stdio) MCP server that convenes a board of AI advisor personas (Sun Tzu, Marcus Aurelius, Machiavelli, Epictetus, plus your own) grounded in public-domain texts.

Differentiator: a fail-closed fidelity contour — every quote marked verbatim is checked **word-for-word against its source by code** (deterministic, no LLM self-judging); outside the corpus the advisor abstains instead of fabricating. Runs locally, no keys. Listed on the official MCP Registry as `io.github.ilyautov/consilium-principis`.

Single line added to the **Developer Productivity** section, standard format.