### PR TITLE
Add seo-rank-audit to DevOps & Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [seo-rank-audit](https://github.com/ducrz/seo-audit-marketplace) - Audits a site and scores it 0-100 per criterion, separately for Google and Bing, based on documented ranking factors. Real Core Web Vitals via PageSpeed Insights, optional Bing Webmaster Tools data, unmeasurable items marked unverified instead of guessed. No API key or signup required.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds [seo-rank-audit](https://github.com/ducrz/seo-audit-marketplace), an open-source Claude Code skill that audits any site and scores it 0-100 per criterion, separately for Google and Bing, based on each engine's documented ranking factors.

- Structural page collector (titles, meta, headings, canonical, schema, robots, sitemap, HTTPS, alt, internal links) — no API key needed
- Real Core Web Vitals via the public PageSpeed Insights API
- Optional Bing Webmaster Tools data for the user's own verified sites
- Anything unmeasurable (backlinks, manual penalties) is marked "unverified" and excluded from the score instead of being guessed

MIT licensed. Follows the same external-link pattern already used for `aws-cost-saver`, `Manifest`, and `MyVibe` in this same section.