### PR TITLE
Add refyner plugin (second-brain research + capture)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -249,6 +249,16 @@
       "author": {
         "name": "Composio"
       }
+    },
+    {
+      "name": "refyner",
+      "source": "./refyner",
+      "description": "Companion for your Refyner second brain — research grounded in what you've saved, plus propose→confirm capture. Bundles the Refyner MCP (OAuth). Free account at refyner.me.",
+      "category": "integrations",
+      "tags": ["second-brain", "knowledge", "research", "mcp", "notes", "memory"],
+      "author": {
+        "name": "Dragos Rebegea"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+- [refyner](./refyner) - Research grounded in your Refyner second brain, with propose→confirm capture. Bundles the Refyner MCP.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 
 ### Frontend & Design

--- a/refyner/.claude-plugin/plugin.json
+++ b/refyner/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "refyner",
+  "description": "Companion for your Refyner second brain: research grounded in your saved knowledge, plus propose→confirm capture. Requires a free Refyner account (https://refyner.me).",
+  "version": "0.1.0",
+  "author": {
+    "name": "Dragos Rebegea",
+    "email": "dragos.rebegea@buidly.com"
+  },
+  "license": "MIT",
+  "homepage": "https://refyner.me",
+  "repository": "https://github.com/buidly/refyner-claude",
+  "keywords": ["refyner", "second-brain", "mcp", "research", "notes", "knowledge"],
+  "mcpServers": {
+    "refyner": {
+      "type": "http",
+      "url": "https://refyner.me/api/mcp"
+    }
+  }
+}

--- a/refyner/skills/second-brain/SKILL.md
+++ b/refyner/skills/second-brain/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: second-brain
+description: Use when the user researches a topic that could draw on their own saved knowledge, or wants to recall or save something in their Refyner second brain — "research X using my second brain", "what have I saved about Y", "save this to my second brain", "add this to Refyner", "check my vault". Requires the bundled Refyner MCP (connect once via /mcp).
+---
+
+# Refyner Second Brain
+
+Ground research in the user's own saved knowledge, and capture new insights with
+their confirmation — using the Refyner MCP tools bundled with this plugin.
+
+## Prerequisites
+
+This skill needs the `refyner` MCP server (bundled with this plugin) connected
+and authenticated. If the `search_vault` tool is not available:
+
+1. Tell the user to run `/mcp`, select **refyner**, and choose **Authenticate**
+   (a one-time browser OAuth login).
+2. A free Refyner account is required — https://refyner.me.
+
+Do not fabricate vault contents. If the tools are unavailable, say so and stop.
+
+## Workflow
+
+### Researching a topic → check the second brain first
+
+1. Call `search_vault(query)` with the user's topic BEFORE answering. This
+   returns snippets of what they've already saved (articles, transcripts, notes).
+2. For the most relevant hits, call `get_vault_entry(id)` to read the full text.
+3. Combine that with your own web search, then answer — clearly distinguishing
+   **what came from the user's second brain** vs. what came from the web.
+
+### Saving something → always propose, never auto-save
+
+1. When something is worth keeping, call `propose_to_vault(...)`. This does NOT
+   write — it returns a normalized preview plus duplicate signals
+   (`duplicate_status`, `exact_match`, `similar_existing`).
+2. Show the user the proposal, including any duplicates. Let them decide.
+3. Only after the user confirms, call `confirm_vault_capture(...)` with the
+   `normalized` fields from the proposal. Never call `confirm_vault_capture`
+   without an explicit confirmation.
+
+### Reference
+
+The `refyner://vault-guide` MCP resource documents this same flow — consult it
+if unsure.
+
+## Examples
+
+- "Research context engineering — check my second brain too." → `search_vault` →
+  `get_vault_entry` on top hits → web search → synthesized answer with sources.
+- "Save this thread to my second brain." → `propose_to_vault` → show preview →
+  `confirm_vault_capture` after the user says yes.
+- "What have I saved about pricing?" → `search_vault("pricing")` → summarize hits.


### PR DESCRIPTION
## Summary
- Vendors the `refyner` Claude Code plugin at repo root (`./refyner`), matching the existing local-plugin convention (e.g. `connect-apps`).
- Bundles the Refyner MCP server (OAuth, `https://refyner.me/api/mcp`) and the `second-brain` skill, which grounds research in the user's saved Refyner knowledge and supports propose→confirm capture.
- Adds a `refyner` entry to `.claude-plugin/marketplace.json` under the `integrations` category.
- Adds a one-line entry to the README's Integrations section.

## About Refyner
Refyner (https://refyner.me) is a personal "second brain" app. This plugin lets Claude Code research grounded in what a user has already saved to Refyner, and propose new captures back into it (with explicit user confirmation before anything is written). Requires a free Refyner account; the bundled MCP server authenticates via OAuth.

Source of truth for the plugin: https://github.com/buidly/refyner-claude

## Verified
- `.claude-plugin/marketplace.json` parses as valid JSON (`python3 -m json.tool`).
- Plugin directory structure matches the existing local-plugin convention.

## Not verified (maintainer to confirm)
- [ ] End-to-end install + MCP OAuth connection in a live Claude Code session.
