### PR TITLE
Add claude-sudo to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
+- [claude-sudo](https://github.com/sutharsan-311/claude-sudo) - Lets `sudo` work in Claude Code's Bash tool. A PreToolUse hook asks for CLI approval on any command that needs root, then routes the password through GNOME Keyring instead of the transcript. Linux only.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## Summary
- Adds [claude-sudo](https://github.com/sutharsan-311/claude-sudo) to the Documentation & Security section.
- Lets `sudo` work in Claude Code's Bash tool: a `PreToolUse` hook asks for CLI approval on any command that needs root, then routes the password through GNOME Keyring via `SUDO_ASKPASS` instead of the transcript or the model. Linux only.

## Checklist
- [x] Addresses a real use case (`sudo` otherwise hangs in the Bash tool until timeout)
- [x] Doesn't duplicate existing functionality in the list
- [x] Follows the existing external-link entry format (see `security-sweep`, `asqav-claude-code`)
- [x] Tested — repo has a test suite (`test.sh`, 11 assertions) and CI on GitHub Actions