### PR TITLE
Add toolbay to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
-- [toolbay](https://github.com/sriptcollector/toolbay-skills) - Marketplace of 15 free MIT-licensed skills, each written from a real defect found in a production codebase: PR review, N+1 query detection, migration safety, webhook correctness, prompt-injection surface mapping, API route auth sweeps, and env/deploy drift.
+- [toolbay](https://github.com/sriptcollector/toolbay-skills) - Marketplace of 20 free MIT-licensed skills, each written from a real defect found in a production codebase: PR review, N+1 query detection, migration safety, webhook correctness, prompt-injection surface mapping, API route auth sweeps, and env/deploy drift.
 
 ### Backend & Architecture
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [toolbay](https://github.com/sriptcollector/toolbay-skills) - Marketplace of 15 free MIT-licensed skills, each written from a real defect found in a production codebase: PR review, N+1 query detection, migration safety, webhook correctness, prompt-injection surface mapping, API route auth sweeps, and env/deploy drift.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [toolbay](https://github.com/sriptcollector/toolbay-skills) under **Code Quality & Testing**.

A marketplace of 15 free, MIT-licensed Claude Code skills:

```
/plugin marketplace add sriptcollector/toolbay-skills
```

Each skill was written from a real defect found in a production codebase and run against a real repository before publishing. They cover PR review, N+1 query detection, migration safety, webhook correctness, prompt-injection surface mapping, API route auth sweeps, env and deploy drift, dependency-outage blast radius, and crawlability auditing.

Against your checklist:

- **Addresses a real use case** — every skill came from an actual production bug, not a category we thought sounded useful.
- **Doesn't duplicate existing functionality** — the closest neighbour here is `code-review`, which reviews a diff generally. These are narrow and specific: one checks the four webhook bugs that cost money, another maps what untrusted text reaches your model and what it can then do, another proves what is deployed matches the commit you think shipped.
- **Follows the template structure** — the repo ships `.claude-plugin/marketplace.json`; each skill is `skills/<name>/SKILL.md` with valid frontmatter.
- **Has been tested** — installed from a clean clone via `/plugin marketplace add` and `/plugin install`, verified on disk.

No signup, no telemetry, nothing gated. README-only change, one line.
