### PR TITLE
Add mneme (memory) and Mergen Verdict (verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [Mergen Verdict](https://github.com/OnourImpram/mergen) - Independent verification of completion claims. Re-derives the evidence from the repository itself, applies a risk floor that cannot be downgraded, and returns pass, conditional_pass, fail or unverifiable instead of assuming done.
 
 ### Backend & Architecture
 
@@ -157,6 +158,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [mneme](https://github.com/OnourImpram/mneme) - Local-first memory across sessions where Markdown stays the source of truth and the index is a rebuildable artifact. No model runs on the Stop path, and redaction happens before any derived store.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Two Claude Code plugins I maintain, added as external links following the existing pattern in the list (20 entries already link out).

**Code Quality & Testing — Mergen Verdict**

An executor reporting *done* has made a claim, not a proof. Mergen re-derives the evidence from the repository itself, applies a risk floor that cannot be downgraded, and returns `pass`, `conditional_pass`, `fail` or `unverifiable`. An `unverifiable` never becomes a `pass` and never runs the next stage. Ships 15 skills plus verification hooks.

`pip install mergen-verdict` · Apache-2.0 · v2.1.2

**Developer Productivity — mneme**

Local-first memory across sessions where Markdown stays the source of truth and the index is a rebuildable artifact. No model runs on the Stop path, CI fails the build if a lifecycle hook imports the network, and retrieval is held to a locked benchmark baseline.

`pipx install mneme-cc-plugin` · Apache-2.0 · v3.6.2

**Against the contribution checklist**

- *Addresses a real use case* — both are published, versioned and installable today, not concepts.
- *Doesn't duplicate existing functionality* — no memory plugin is currently listed; the closest neighbours are `backlog` (task state) and `context-mode` (output handling), which solve different problems. In Code Quality the closest is `AgentLint`, which lints repos for agent compatibility rather than verifying completion claims.
- *Tested* — both carry CI, tagged releases, changelogs and a `CITATION.cff`; mneme is also in the official MCP registry.
- *Follows the template structure* — entries appended to the end of their sections, which are not alphabetically ordered, so the diff is two added lines and nothing else.

Happy to move either entry, shorten the descriptions, or vendor them in as folders if you would rather have them in-repo.

Disclosure: I am the author of both projects; this pull request was prepared with an AI assistant.
