### PR TITLE
Add Remote Workspace Fit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Remote Workspace Fit](https://github.com/Anchras/terminalbox-tools/tree/main/plugins/remote-workspace-fit) - Read-only repository audit that recommends a rebuildable Claude Code web session, a persistent development workspace, or further investigation based on tracked project evidence.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What changed

Adds Remote Workspace Fit to Developer Productivity as an external Claude Code plugin.

## Why

The plugin addresses a distinct workflow decision: whether repository evidence supports a rebuildable Claude Code web session, a persistent development workspace, or more investigation. It does not duplicate an existing listing.

## User impact

Readers get a free, read-only repository audit with no scripts, hooks, MCP servers, telemetry, or network integration.

## Validation

- Public source URL returns HTTP 200
- `claude plugin validate .` passes for the marketplace
- `claude plugin validate plugins/remote-workspace-fit` passes
- A clean isolated install from `Anchras/terminalbox-tools` enables version 0.1.1
- README diff is one external listing line and passes `git diff --check`
