### PR TITLE
Add backbrief to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
+- [backbrief](https://github.com/EvgenSmith/backbrief) - Turn call transcripts into tracked tasks and a company memory vault — markdown digests with (MM:SS) anchors in your own git repo, tasks deduped against your live tracker backlog.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
 ### Companion & Personality


### PR DESCRIPTION
Adds [backbrief](https://github.com/EvgenSmith/backbrief) — a Claude Code plugin that turns call transcripts into a markdown vault the team owns: per-call digests with (MM:SS) anchors, decisions and next steps, plus tasks extracted and deduplicated against the live tracker backlog before anything is created.

- Real use case: generalized from 3.5 months and 200+ calls running in production before release.
- No duplication: nothing in the list covers meeting capture or team memory today.
- Tested: claude plugin validate passes; the kit ships its own test suite (render/smoke/e2e) and a publish gate.
- Zero npm dependencies, MIT (the optional n8n pipeline under pipeline/ is BSL 1.1).