### PR TITLE
Add c-brain plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [c-brain](https://github.com/Yuno15-bb/c-brain) - Persistent memory that grows across sessions. What you work out once is distilled into a linked note and surfaced automatically next time, from any project. Engine and notes live in separate directories, so updates never touch your work. Recall quality is measured and gated in CI.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Persistent memory for CLI agents: what you work out once is distilled into a linked note and surfaced automatically next time, from any project.

Meets the contributing criteria:

- **Real use case** — agents are amnesic between sessions. This is the part that remembers: recall is injected on every prompt, and `/c-brain:distill` turns what was just solved into a filed, linked note.
- **No duplication** — the closest neighbours in this section store *tasks* or compress *context*. This stores understanding and retrieves it by relevance.
- **Follows the structure** — `.claude-plugin/plugin.json`, `skills/`, `agents/`, `hooks/`. `claude plugin validate --strict` passes.
- **Tested** — public CI runs a leak check over the full history, a complete install / selftest / uninstall on a macOS runner, update and rollback against a local upstream, every migration replayed twice, and a recall benchmark with enforced thresholds.

Notes: macOS only for the moment (the four places that assume it are named in the README). Apache 2.0. Nothing leaves the machine — no telemetry, no network call beyond `git pull`.

Repo: https://github.com/Yuno15-bb/c-brain