### PR TITLE
docs: add cognitive-powers to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [cognitive-powers](https://github.com/Drizzy07x/cognitive-powers) - 16 skills for focused execution with durable evidence and independent verification, spanning diagnosis, resumable multi-step execution, and delivery audits. Each release ships a compatibility matrix of 108 CI-backed cells. Claude Code and Codex.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds one entry under **Code Quality & Testing** for [cognitive-powers](https://github.com/Drizzy07x/cognitive-powers), a Claude Code and Codex plugin packaging 16 skills for focused execution and independent verification.

Listed as an external link rather than a vendored folder, following the pattern already used in this list for `AgentLint`, `maestro-orchestrate`, and `aws-cost-saver`. The plugin has its own installer and marketplace manifest, so copying the tree in would duplicate a moving target.

Against the contributing checklist:

- **Real use case** — the three core flows are a bounded implementation or diagnosis, resumable execution whose evidence survives context compaction, and an audit of a completion claim against current evidence.
- **No duplication** — the nearest entries here generate or review code. This one does not review a diff; it verifies that a claimed outcome is backed by evidence, and abstains when the evidence is missing or stale rather than reporting success.
- **Tested** — validation runs across twelve cells (Ubuntu, Windows, macOS x Python 3.11, 3.13 x two pinned Codex CLI versions). Every release is built twice and compared byte for byte, and ships a compatibility matrix of 108 cells covering clean install, upgrade, rollback, CRLF/LF, symlinks, Unicode paths, corrupt state, and a checkout without Git. Cells without a receipt stay `unknown` rather than being assumed to work.
- MIT licensed.

Happy to move it to a different category or shorten the description if it reads long.