### PR TITLE
Add drift to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Code Quality & Testing
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
+- [drift](https://github.com/mick-gsk/drift) - Tells your agent when it is about to build something that already exists. Cross-language duplicate and boundary guard over a SQLite index of your repo: 8 languages, no dependencies, under 100 ms per edit.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.


### PR DESCRIPTION
Adds one line under **Code Quality & Testing**, following the external-repo pattern already used by AgentLint.

```
- [drift](https://github.com/mick-gsk/drift) - Tells your agent when it is about to build something that already exists. Cross-language duplicate and boundary guard over a SQLite index of your repo: 8 languages, no dependencies, under 100 ms per edit.
```

### What it does

After every edit the agent makes, drift says one of two things — or, most of the time, nothing:

```
drift:
  - `ValidateToken` already exists as `validate_token` in src/auth/tokens.py:1
  - first import from src/api/ into src/db/ anywhere in this repository
```

Names are normalised, so a Go `ValidateToken` matches a Python `validate_token`. Boundaries are observed rather than configured — the index records which directory-to-directory imports the repository actually contains, so a first-ever crossing stands out without anyone writing a rule.

### Against the checklist

- **Addresses a real use case** — duplication introduced by agents that cannot see the whole repository.
- **Doesn't duplicate existing functionality** — AgentLint checks a repo for agent compatibility; `code-review` reviews a diff. drift answers one structural question per edit, inside the loop, from an index rather than an analysis.
- **Tested** — 6978 tests, plus nine hard gates covering latency, import hygiene, ground-truth recall, install time and counter honesty.
- **Try it without installing** — `bash demos/guard-in-30-seconds.sh` builds a two-file repo, runs the real hook with a real payload, and prints what the agent receives. Under a second.

### Numbers

| | |
|---|---|
| Install | two lines, no `pip install`, no configuration |
| Latency | 72 ms p95 before an edit, 87 ms after, on a 344-file repository |
| Dependencies | none — `sqlite3`, `ast` and `json` from the standard library, enforced by a test |
| Noise | speaks on 0–5.6 % of files, replayed over requests, fastapi, date-fns, flask and axios |
| Writes into your repo | nothing; the index lives in `~/.cache/drift` |

MIT.