### PR TITLE
Add claude-speak: TTS/accessibility plugin (macOS say / Linux espeak-ng)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [Backend & Architecture](#backend--architecture)
   - [DevOps & Performance](#devops--performance)
   - [Documentation & Security](#documentation--security)
+  - [Accessibility](#accessibility)
   - [Developer Productivity](#developer-productivity)
   - [Companion & Personality](#companion--personality)
 - [Getting Started](#getting-started)
@@ -146,6 +147,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
+
+### Accessibility
+
+- [claude-speak](https://github.com/JosephScript/claude-speak) - Gives Claude Code a voice via your OS's built-in TTS (`say` on macOS, `espeak-ng`/`espeak` on Linux). On-demand `/speak` (verbatim or LLM-summarized) plus an automatic Stop-hook mode that reads every response aloud, with adjustable rate/voice/truncation. No API keys, no external services, no telemetry.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## What
Adds a new **Accessibility** category and lists [claude-speak](https://github.com/JosephScript/claude-speak) — gives Claude Code a voice via the OS's built-in TTS engine (`say` on macOS, `espeak-ng`/`espeak` on Linux).

## Why
No API keys, no external services, no telemetry — everything runs locally. Built as an accessibility tool for anyone who finds reading dense terminal output slow, tiring, or difficult, and doubles as the output half of a hands-free loop when paired with Claude Code's existing voice-dictation input.

## Notes
- Cross-platform, tested via a 34-test bats-core suite in CI on `macos-latest` and `ubuntu-latest`.
- MIT licensed, tagged release `v1.1.0`.
- No new category existed for accessibility-focused plugins, so I added one rather than force-fitting into an unrelated section.