### PR TITLE
Add ui-review (automated UI/UX review via agent-browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
-- [ui-review](https://github.com/roney492/ui-review) - Automated UI/UX review via the agent-browser CLI: text overflow, wrapping, responsiveness across breakpoints, dark mode, WCAG zoom/reflow, codebase-mapped fixes, and baseline/diff regression mode.
+- [ui-review](https://github.com/cdmx-in/ui-review) - Automated UI/UX review via the agent-browser CLI: text overflow, wrapping, responsiveness across breakpoints, dark mode, WCAG zoom/reflow, codebase-mapped fixes, and baseline/diff regression mode.
 
 ### Backend & Architecture
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [ui-review](https://github.com/roney492/ui-review) - Automated UI/UX review via the agent-browser CLI: text overflow, wrapping, responsiveness across breakpoints, dark mode, WCAG zoom/reflow, codebase-mapped fixes, and baseline/diff regression mode.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [ui-review](https://github.com/cdmx-in/ui-review) under Code Quality & Testing.

A Claude Code plugin/skill that audits web pages across common breakpoints using the agent-browser CLI: text overflow/clipping, wrapping, horizontal scroll, overlapping elements, tap targets, dark mode, WCAG zoom/reflow stress tests. Maps findings back to source files when run against a local dev server, and includes a baseline/diff regression mode. Installable via `/plugin marketplace add cdmx-in/ui-review`. MIT licensed.