### PR TITLE
Add q-ring (OS keychain secrets over MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
+- [q-ring](https://github.com/I4cTime/q-ring) - Secrets from the OS keychain (macOS Keychain, Linux Secret Service, Windows Credential Vault) over MCP: 44 policy-governed tools plus skills and commands for secret scanning, rotation, redacted exec, and a tamper-evident audit log. Install via `/plugin marketplace add I4cTime/q-ring`.
 
 ### Developer Productivity
 


### PR DESCRIPTION
Adds [q-ring](https://github.com/I4cTime/q-ring) to **Documentation & Security**.

- **Real use case**: secrets management for AI coding agents — keys live in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Vault) instead of plaintext `.env` files, exposed through 44 policy-governed MCP tools.
- **Not a duplicate**: existing security entries scan or advise; q-ring is a secrets *manager* (storage, rotation, redacted exec, tamper-evident audit log). It complements scanners like security-sweep.
- **Plugin structure**: the repo root has `.claude-plugin/marketplace.json`; the plugin ships 5 skills, 8 commands, 2 agents, and the MCP server config. `claude plugin validate` passes.
- **Tested**: installable today via `/plugin marketplace add I4cTime/q-ring`; v0.14.1 on npm (`@i4ctime/q-ring`), AGPL-3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)