### PR TITLE
Add dev-report plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
+- [dev-report](https://github.com/delpicorp/dev-report) - Writes up a coding session for a non-technical decision-maker: what was done, why that way, what is still open, and what needs their call. Keeps the full engineering reasoning and defines every technical term at first use. Ships Korean, Japanese, and Spanish command aliases.
 
 ### Developer Productivity
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
-- [dev-report](https://github.com/delpicorp/dev-report) - Writes up a coding session for a non-technical decision-maker: what was done, why that way, what is still open, and what needs their call. Keeps the full engineering reasoning and defines every technical term at first use. Ships Korean, Japanese, and Spanish command aliases.
+- [dev-report](https://github.com/delpicorp/dev-report) - Explains a Claude Code session in plain language: what changed, why that approach was chosen, what is still unfinished or unverified, and what to do next. Every technical term is explained at first use. Ships Korean, Japanese, and Spanish command aliases.
 
 ### Developer Productivity
 


### PR DESCRIPTION
Adds [dev-report](https://github.com/delpicorp/dev-report) to **Documentation & Security**.

Listed as an external link rather than a vendored folder, matching `security-sweep`, `asqav-claude-code`, and `CCHub` in the same file. That keeps a single source of truth — a copy in this repo would go stale against the upstream plugin without anyone noticing.

### What it does

You finish a long Claude Code session. A dozen files changed and several implementation decisions were made along the way, but the end-of-session summary is file names and function names — accurate, and written for someone reading the diff alongside it. Asking for it "simply" removes the reasoning too.

dev-report explains the session in plain language instead: what was built or changed, why that approach was chosen, what is still unfinished or unverified, and what to do next. Technical terms aren't stripped out — they're explained the moment they first appear, so the reasoning survives.

Two rules do most of the work. Every finding leads with the raw artifact — the actual log line, the actual count — before it gets explained. And the section on how a problem was solved has to name the option that was rejected and what would have gone wrong, which is the only way to check a technical decision you can't read yourself.

### Plugin details

```
/plugin marketplace add delpicorp/dev-report
/plugin install dev-report@delpicorp
```

Installs `/dev-report` plus localized aliases `/개발보고`, `/開発報告`, and `/informe-desarrollo`. Single skill, no agents, hooks, or MCP servers; about 380 always-on tokens. Explicit-only, so it does not fire on a casual "what did you just do?". MIT licensed, worked example reports included.

*Updated 2026-08-04: reworded the entry and this description to lead with what the plugin does rather than who it's for.*
