### PR TITLE
Add vibestretch (stretch nudges on long agent turns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [vibestretch](https://github.com/Eliasjunit/vibestretch) - Stretch, movement and 20-20-20 eye nudges while your agent works. Fires only after real agent-wait time, so short turns stay silent, and never while you are away from the machine. POSIX shell hooks, zero dependencies, no telemetry, no links in your terminal.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [vibestretch](https://github.com/Eliasjunit/vibestretch) under **Developer Productivity** — one line in the README, linking out to the plugin repo (same shape as the other external entries in that section).

**What it does.** While your agent grinds through a long turn, you sit there — slouched, not blinking. vibestretch prints one line into the session with a stretch, a micro-workout, or a 20-20-20 eye break, plus a soft bundled chime and an optional status line segment.

**Why it isn't noise.** The nudge only fires when you have genuinely been waiting on the agent: the current turn has been running a while, enough agent-wait time has accumulated since your last break, and the cooldown has passed. Short turns and quick back-and-forth stay silent. It also reads the OS keyboard/mouse idle clock on macOS, so an agent running overnight never chimes at an empty chair.

**Shape.** Three hooks (`UserPromptSubmit`, `PostToolUse`, `Stop`) wired to a few POSIX shell scripts. No dependencies, no daemon, no telemetry, nothing leaves the machine — and no links or self-promo printed into anyone's terminal, which is a deliberate rule of the project rather than an oversight.

Tested end to end from a clean install (`/plugin marketplace add Eliasjunit/vibestretch` → install → nudge fires from the marketplace cache); `claude plugin validate --strict` passes. Doesn't duplicate anything currently on the list — the closest neighbour, claude-familiar, is a companion/personality plugin.