### PR TITLE
Add legacy-guardrails to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.
+- [legacy-guardrails](https://github.com/JungJaeYeop/legacy-guardrails) - Deterministic safety hooks for legacy systems: blocks Write/Edit and shell writes to protected paths, enforces read-only database queries through MCP tools, and logs context compactions. Supports maintenance and Strangler Fig migration workflows.
 
 ### Developer Productivity
 


### PR DESCRIPTION
## What

Adds [legacy-guardrails](https://github.com/JungJaeYeop/legacy-guardrails) to the **Documentation & Security** section.

## About the plugin

Deterministic safety hooks for working on legacy systems with Claude Code — rules enforced at the hook level, not suggested at the prompt level:

- **guard_legacy_write** — blocks Write/Edit targeting protected paths (payment modules, production configs, vendor dirs, or a whole legacy tree during a Strangler Fig migration)
- **guard_bash_write** — blocks shell commands that write into protected paths (echo >, sed -i, rm, mv, Set-Content, ...), closing the bash bypass; read-only shell usage stays allowed
- **guard_db_readonly** — intercepts MCP database query tools and rejects anything other than SELECT/SHOW/DESCRIBE/EXPLAIN/WITH; fail-closed if the SQL can't be inspected
- **compact_logger** — logs every context compaction to keep long sessions traceable

## Checklist

- Addresses a real use case: born from a JSP/Java → Spring Boot migration and maintenance of a 14-year-old PHP system
- No duplicate: no existing entry covers write-protection hooks for legacy codebases
- Standard plugin structure (.claude-plugin/plugin.json, hooks/, commands/), MIT licensed
- Tested: 42 unit tests, v0.2.0 released

🤖 Generated with [Claude Code](https://claude.com/claude-code)