### PR TITLE
Add OutageDeck incident triage plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [perf](./perf) - Performance analysis and optimization. Identify bottlenecks and improve speed.
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
-- [OutageDeck](https://github.com/outagedeck/codex-plugins) - Checks live cloud and SaaS status, incidents, and uptime before code changes, bundling a keyless 14-tool MCP server with a focused dependency-outage triage skill.
+- [OutageDeck](https://github.com/outagedeck/codex-plugins) - Checks vendor-published cloud and SaaS status, incidents, and observed uptime history before code changes, bundling a keyless MCP server with a focused dependency-outage triage skill.
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [perf](./perf) - Performance analysis and optimization. Identify bottlenecks and improve speed.
 - [audit-project](./audit-project) - Full project audit for code quality, dependencies, security, and best practices.
+- [OutageDeck](https://github.com/outagedeck/codex-plugins) - Checks live cloud and SaaS status, incidents, and uptime before code changes, bundling a keyless 14-tool MCP server with a focused dependency-outage triage skill.
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))


### PR DESCRIPTION
## Summary

Adds OutageDeck to DevOps & Performance as an external Claude Code plugin for checking upstream cloud and SaaS incidents before changing code.

## Why it fits

- Real diagnostic use case: distinguish provider incidents from application regressions.
- Native Claude Code marketplace and plugin manifests.
- Bundles one focused triage skill and a hosted Streamable HTTP MCP server.
- Public status tools are read-only, keyless, and cover cloud and SaaS providers through their official status feeds.
- Does not duplicate the existing performance, audit, cost, or observability entries.

## Validation

- `claude plugin validate --strict plugins/outagedeck`: passed
- `claude plugin validate --strict .`: passed
- A clean GitHub-backed marketplace install returned the expected skill and MCP server.
- Public CI validates package structure and tool discovery from the hosted MCP endpoint.
- The portable skill has a [canonical skills.sh listing and passing Snyk audit](https://www.skills.sh/outagedeck/codex-plugins/triage-dependency-outages).

Disclosure: I maintain OutageDeck and am submitting its listing.
