### PR TITLE
Add Parallax to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Code Quality & Testing
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
+- [Parallax](https://github.com/propersloth/parallax-threejs) - Three.js/GLSL debugging that correlates live scene graph, browser console, GPU state, and pixels into one diagnosis instead of a screenshot. Includes git-SHA-indexed visual regression testing.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.


### PR DESCRIPTION
Adds [Parallax](https://github.com/propersloth/parallax-threejs), a Claude Code plugin for vanilla three.js/GLSL debugging — correlates the live scene graph, browser console, raw GPU state, and pixels into one diagnosis instead of guessing from a screenshot. Includes git-SHA-indexed checkpoint/diff visual regression testing and a shader-reviewing subagent.

Linked externally rather than vendored, following the precedent already set by AgentLint/kaggle-skill/maestro-orchestrate in this same section — happy to vendor the plugin folder instead if you'd prefer that for consistency.