### PR TITLE
Add one-brain to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [one-brain](https://github.com/Prophet-git/one-brain-plugin) - Shared team memory for Claude Code. Decisions and context are saved with author and date attached, survive `/clear`, and reach every teammate's next session. Remote MCP server with OAuth, listed in the official MCP registry as `io.github.Prophet-git/one-brain`. ([Website](https://onebrain.prophet.lat))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [one-brain](https://github.com/Prophet-git/one-brain-plugin) to the Developer Productivity section.

Shared team memory for Claude Code: what one teammate records, the whole team gets at the start of their next session. Remote MCP server with OAuth, published in the official MCP registry as `io.github.Prophet-git/one-brain`.

Link-only entry, same as the other external plugins in the list. Happy to adjust the wording or move it to another section.