### PR TITLE
Add NXTG-Forge Plugin to Backend & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [mcp-builder](./mcp-builder) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs.
 - [agent-sdk-dev](./agent-sdk-dev) - Claude Agent SDK development helper for building custom AI agents.
 - [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, and standalone commands for code review, debugging, security audit, and more.
+- [NXTG-Forge Plugin](https://github.com/nxtg-ai/forge-plugin) - Zero-dependency governance plugin for Claude Code — 21 commands, 22 agents, 29 skills (research→plan→delegate→adversarial-verify→deploy pipeline, CRUCIBLE test-quality auditing, promise tracking).
 
 ### DevOps & Performance
 


### PR DESCRIPTION
Adds one resource under **Backend & Architecture** (alongside the existing multi-agent orchestration entries):

- [NXTG-Forge Plugin](https://github.com/nxtg-ai/forge-plugin) - Zero-dependency governance plugin for Claude Code — 21 commands, 22 agents, 29 skills (research→plan→delegate→adversarial-verify→deploy pipeline, CRUCIBLE test-quality auditing, promise tracking).

**Checklist**
- Addresses a real use case: automated governance/quality gates and agent orchestration for Claude Code.
- Doesn't duplicate existing functionality: closest neighbor is multi-agent orchestration; this adds a governance pipeline plus test-quality auditing (CRUCIBLE) and promise tracking.
- Public repo, MIT licensed, standard Claude Code plugin structure (`.claude-plugin/plugin.json`, commands, agents, skills).
- One entry, alphabetically-neutral placement within the section.