### PR TITLE
Add project-brain (cross-project memory plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [project-brain](https://github.com/vikasgrac/project-brain) - Cross-project memory for Claude Code. Auto-archives every session to plain Markdown, redacts secrets, and distills notes into per-project pages with a small index injected at session start. Index-first recall with no vector database; cross-machine via any folder sync.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds **project-brain** to Developer Productivity: cross-project memory for Claude Code (MIT).

- Auto-archives every session to plain Markdown via SessionEnd/PreCompact hooks, with secret redaction on by default
- Distills sessions into decision/fact notes, compiled into per-project pages plus a ~20-line index injected at session start
- Index-first recall (index → project page → notes → grep the archive) — no vector DB, no external service
- Cross-machine memory by placing the vault in any synced folder
- Installable as a standard plugin: `/plugin marketplace add vikasgrac/project-brain`

Addresses a real use case (re-explaining project context every session; transcript loss after Claude Code's 30-day cleanup) and doesn't duplicate an existing entry — nearest neighbors are task/context managers (backlog, context-mode), not conversation-memory capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)