### PR TITLE
Add tailtest to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
+- [tailtest](https://github.com/avansaber/tailtest) - Generates and runs adversarial tests on every file Claude Code edits, via a PostToolUse hook. 8 languages, no commands to run. MIT.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.


### PR DESCRIPTION
Adds **tailtest** as an external link under **Code Quality & Testing**, matching the format of the other external entries such as `AgentLint`.

tailtest is a Claude Code plugin that generates and runs tests automatically after every file edit. It hooks PostToolUse to queue the edited file, generates production-shaped scenarios through a rule layer, runs them against the project's existing test runner, and surfaces failures back to Claude inside the same turn.

What makes it a distinct entry from the slash-command test writers already listed (`test-writer-fixer`, for instance): those run on demand, tailtest runs on the hook, so there is no command to remember and no decision for the agent to skip.

- Adversarial mode biases scenario generation toward breakage paths rather than happy-path coverage
- 8 languages: Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- Zero config for the default setup
- MIT, no telemetry
- Bugs found and reported upstream in open-source Python repos, with maintainer-merged fixes: https://www.tailtest.com/case-studies/

Repo: https://github.com/avansaber/tailtest