### PR TITLE
Add creative-stack to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
+- [creative-stack](https://github.com/le-19-stvn/creative-stack) - Adaptive, anti-slop stack for Claude Code. A router detects what you're building and mounts only the departments that project needs; a taste layer confronts every output against your declared references so nothing ships generic. Nothing by default, everything by decision.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.


### PR DESCRIPTION
Adds creative-stack — an adaptive, anti-slop stack for Claude Code. It routes each new project to only the departments it needs and enforces a taste layer that rejects generic output.

- Real use case: keeps a human point of view in AI-assisted creative/dev work
- No duplication: it's a multi-department marketplace, not an existing single plugin
- MIT licensed, public repo