### PR TITLE
Add claude-markitdown-hook to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [claude-markitdown-hook](https://github.com/AndrewAvery7/claude-markitdown-hook) - Converts PDFs and Office files mentioned in a prompt to markdown before Claude reads them, and catches markitdown's silent "exit 0 on empty extraction" failure on scans and image-only PDFs. Requires markitdown.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary
- Adds [claude-markitdown-hook](https://github.com/AndrewAvery7/claude-markitdown-hook) to the Developer Productivity section — a UserPromptSubmit hook that converts PDFs/Office files mentioned in a prompt to markdown before Claude reads them, and specifically guards against markitdown's silent "exit 0 on empty extraction" behavior on scanned/image-only documents.

This is a link-only entry pointing at the external repo (same pattern as AgentLint, context-mode, security-sweep, and others already in this section), not a `./plugin-folder` addition, since the project ships as a standalone hook rather than a bundled Claude Code plugin package.

## Test plan
- [ ] Link resolves and renders correctly in the README
- [ ] Entry follows existing list formatting/style in the section