### PR TITLE
Add Yaps plugins marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [yaps-plugins](https://github.com/richawo/yaps-plugins) - Marketplace of 11 plugins that connect Claude Code to the Yaps desktop app for on-device voice dictation, file and meeting transcription, subtitles and captions, audio cleanup, image background removal, text-to-speech, translation, and local Markdown memory.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds [richawo/yaps-plugins](https://github.com/richawo/yaps-plugins) to the Integrations section: a Claude Code plugin marketplace with 11 plugins that drive the Yaps desktop app (voice dictation, file and meeting transcription, subtitles and captions, audio cleanup, background removal, text-to-speech, translation, and local Markdown memory). All processing happens on-device through the installed app. Install with `claude plugin marketplace add richawo/yaps-plugins`. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)