### PR TITLE
Add conversion-craft (Frontend & Design)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Frontend & Design
 
+- [conversion-craft](https://github.com/nemolabsdev/conversion-craft) - Complete conversion-design team: 9 agents, 16 research-sourced skills, and 3 mechanical QA gates (token lint, declared-contrast check, rendered-page geometry audit) for building high-converting sales pages. Adversarially audited by its own art-director agent.
 - [frontend-design](./frontend-design) - Create distinctive, production-grade interfaces. Avoids generic "AI slop" with bold typography, unique color palettes, and creative layouts.
 - [artifacts-builder](./artifacts-builder) - Suite of tools for creating elaborate, multi-component HTML artifacts using React, Tailwind CSS, and shadcn/ui.
 - [theme-factory](./theme-factory) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.


### PR DESCRIPTION
Adds [conversion-craft](https://github.com/nemolabsdev/conversion-craft) — a complete conversion-design team for Claude Code: 9 agents (including an adversarial art-director on Opus), 16 skills distilled from design-award analysis and Baymard/NN-g/CXL research (every rule sourced and confidence-tagged), and 3 mechanical QA gates including a zero-dependency headless-Chrome audit that measures the rendered page (per-line CPL, fold contracts, computed-style asserts). MIT licensed. The toolkit's own audit trail — 8 rounds, 78 findings — is public in its commit history.