### PR TITLE
Add tuto (YoutubeAnalyzer) to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
+- [tuto (YoutubeAnalyzer)](https://github.com/dingmon1019/YoutubeAnalyzer) - Claude Code plugin that turns YouTube tutorials into verified working knowledge using transcript and frame evidence, with traceable claims and explicit screen-caption conflicts.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.


### PR DESCRIPTION
## What changed

- Added `tuto (YoutubeAnalyzer)` to the Developer Productivity section.
- Linked directly to the MIT-licensed Claude Code plugin repository.

## Why

tuto addresses a gap between transcript summarization and reproducible tutorial use: it analyzes transcript and frame evidence together, records traceable claims, and preserves screen-caption conflicts instead of silently resolving them.

## Validation

- Confirmed the repository contains a Claude Code plugin manifest and installation instructions.
- Confirmed the description reflects the current public v0.3.2 behavior without adding performance claims.
- Ran `git diff --check`.
