### PR TITLE
Add Deposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Deposition](https://github.com/georgedagher/deposition) - Local-only decision log for AI coding agents. Regex-based decision extraction, ChromaDB + local embeddings, zero API calls, nothing leaves disk. Hooks into Stop to auto-index, ships with a recall skill.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Local-only decision log for AI coding agents. Zero API calls — regex-based decision extraction, ChromaDB + local embeddings, nothing leaves disk. Ships as a Claude Code plugin (Stop hook + recall skill) or standalone CLI. MIT licensed.