### PR TITLE
Add claude-code-skills-pack to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [claude-code-skills-pack](https://github.com/wilddoc/claude-code-skills-pack) - Thirteen skills for git workflow, testing, code quality, and infrastructure review. Includes flaky test triage, regression bisect, characterization tests before refactors, CI secret exposure checks, and N+1 query detection.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds `claude-code-skills-pack` to **Code Quality & Testing**.

Thirteen skills covering git workflow, testing, code quality, and infrastructure review. The ones least covered by existing entries in the list:

- `flaky-test-triage` — diagnoses whether a flaky test is leaked state, order dependence, timing, or a genuine race condition, and says plainly when a retry wrapper would be hiding a real bug
- `regression-bisect` — sets up `git bisect` with an automated predicate script, including exit 125 for commits that won't build
- `refactor-safety-net` — characterization tests capturing current behavior before a refactor, including behavior that looks wrong
- `ci-workflow-audit` — `pull_request_target` with untrusted checkout, actions pinned to mutable tags, `|| true` on the test command making CI green while verifying nothing
- `n-plus-one-queries` — N+1 detection including patterns hidden behind serializers and computed properties

Also includes commit-message, changelog-entry, pr-description, test-coverage-gaps, todo-sweep, error-message-audit, log-noise-audit, and dockerfile-review.

Installable as a plugin:

```
/plugin marketplace add wilddoc/claude-code-skills-pack
```

`claude plugin validate` passes clean and the install was verified end to end from GitHub. MIT licensed. Skills only — no MCP servers, hooks, or executable code, so the security surface is limited to instructions.

Happy to adjust the wording, category, or trim the entry if you'd prefer it shorter.