### PR TITLE
Add plainspeak to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [context-mode](https://github.com/mksglu/claude-context-mode) - Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings across 21 benchmarked scenarios.
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
+- [plainspeak](https://github.com/mkt-henry/plainspeak) - Makes Claude report in plain language for people who ship products without reading code. Hides file paths, function names, and library talk; keeps commands, addresses, and keys you must type verbatim. Three intensity levels plus a per-user voice interview, remembered across sessions.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
 ### Companion & Personality


### PR DESCRIPTION
### What

Adds [plainspeak](https://github.com/mkt-henry/plainspeak) under Developer Productivity — one README line, no vendored folder.

### What it does

Claude Code reports work the way you would report it to another engineer: file paths, function names, library choices, code blocks. For people who build real products but do not read code, most of that is noise they cannot act on.

plainspeak changes what Claude says, not how it works. Same engineering, different report.

**Before**

> Added a CartProvider in `src/components/Cart.tsx` using useReducer for state. Defined `addItem` / `removeItem` actions, handled localStorage sync in a useEffect, and split the types out into `types/cart.ts`.

**After**

> Added the shopping cart.
> You can add items and change quantities in the browser now.
> Have a look: click add on a product and check the count goes up right.

Three intensity levels (`lite` / `full` / `strict`), plus a short interview that sets tone, length, formality and formatting. Both persist across sessions.

Commands to type, addresses to open, values to paste, and warnings about anything that costs money, cannot be undone, or goes public are never compressed at any level. Asking for detail lifts every restriction.

### Checklist

- Addresses a real use case — non-developers are a large and growing share of Claude Code users
- Does not duplicate an existing entry in the list
- Tested — `node test/test-hooks.js` covers level switching, persistence, the setup interview and style injection
- MIT licensed

🤖 Generated with [Claude Code](https://claude.com/claude-code)