### PR TITLE
Add ml-pipeline to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [ml-pipeline](https://github.com/jananthan30/ml-pipeline) - Enforces a strict 16-step data-first ML workflow — data inspection, EDA, and problem definition before any model training — with explicit user-permission gates, marimo notebooks, and matplotlib figures at every step. Also installable in Codex and Kimi.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adds [ml-pipeline](https://github.com/jananthan30/ml-pipeline) to the Developer Productivity section.

## Why

Coding agents often jump straight to model training without understanding the data. This plugin enforces a strict 16-step, data-first ML pipeline (inspection → EDA → problem definition → cleaning → engineering → split → features → preprocessing → baseline → training → tuning → evaluation → error analysis → final test → deployment → monitoring) with explicit user-permission gates after each phase, marimo notebooks as the workbench, and matplotlib figures at every data-facing step.

## Checklist

- Real use case: prevents data leakage and premature training in agent-driven ML work
- No duplicate: no existing entry covers ML workflow discipline
- Tested: passes `claude plugin validate`; installed and exercised locally in Claude Code, Codex CLI, and Kimi
- External-repo entry (same pattern as kaggle-skill, context-mode, codebase-graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)