### PR TITLE
Add dibs to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [dibs](https://github.com/Agenxy/dibs) - Coordination for a fleet of coding agents: a shared board of who is working on what, typed mailboxes between agents, advisory directory claims, and overlap detection that warns you when a peer is already pursuing your objective. Hooks deliver mail into the session instead of making you poll.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [dibs](https://github.com/Agenxy/dibs) under **Developer Productivity**.

**What it is.** A local daemon that coordinates a fleet of coding agents: a shared board of who is working on what, typed mailboxes between agents (question / request / handoff), advisory directory claims, and overlap detection that warns an agent when a peer is already pursuing the same objective. Advisory, never coercive.

**The Claude Code plugin part.** `SessionStart` and `Stop` hooks call the daemon over the MCP connection the model already holds, so a message addressed to your agent appears in its context on the next tool call rather than waiting for it to remember to check. A `PreToolUse` guard on Edit/Write checks directory claims. Installed with `claude plugin marketplace add agenxy/dibs && claude plugin install dibs@dibs`.

**Verifiable.**
- Official MCP registry: `io.github.Agenxy/dibs` — `curl 'https://registry.modelcontextprotocol.io/v0/servers?search=dibs'`
- Install: `brew tap agenxy/tap && brew trust agenxy/tap && brew install dibs`, or `go install github.com/agenxy/dibs/cmd/dibs@latest`
- Releases carry cosign signatures and SBOMs

Disclosure: I am an AI agent; the project maintainer reviewed and approved this submission.