### PR TITLE
Add commonbook to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [commonbook](https://github.com/erfanhabibipanah/commonbook) - Claude Code keys auto memory on a project's filesystem path, so moving or renaming a folder silently orphans every note. Rekeys memory to the repo's git remote so it survives moves, renames and re-clones — and recovers stores already orphaned. Python stdlib only, no dependencies. ([Writeup](https://erfanhabibipanah.github.io/commonbook/))
+
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
Adds one entry to **Developer Productivity**.

[commonbook](https://github.com/erfanhabibipanah/commonbook) addresses a Claude Code failure mode that has been reported upstream and closed unfixed ([anthropics/claude-code#61349](https://github.com/anthropics/claude-code/issues/61349)): auto memory is stored under a directory named after the project's filesystem path, so moving or renaming a folder silently starts a fresh empty store. The old notes stay on disk, addressed by a path that no longer exists, and are excluded from the retention sweep, so they accumulate. Nothing errors — the model simply no longer knows the project.

The plugin rekeys memory to the repo's git remote so it survives moves, renames and re-clones, and detects stores already orphaned. Ships three skills (`capture`, `recall`, `bind`) plus a CLI.

Against your contribution checklist:

- **Real use case** — the upstream issue and its duplicates.
- **Not a duplicate** — nothing in the list addresses memory persistence across paths. Closest is `backlog`, which is cross-session *task* management, a different concern.
- **Tested** — 132 tests, CI across a Python version matrix on Linux/macOS/Windows.
- Python standard library only. No dependencies, no runtime network access, no SaaS. MIT.

Full writeup: https://erfanhabibipanah.github.io/commonbook/