### PR TITLE
Add claude-in-chrome to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [claude-in-chrome](https://github.com/hamzahamidi/claude-in-chrome-cli) - Drives your real, logged-in Chrome through the Claude in Chrome extension, so pages behind SSO or a cookie wall work without a fresh profile or a re-login. Bundles a skill on when a real session matters, plus `cic.sh` for shell and cron use.
+
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
Adds `claude-in-chrome` under Developer Productivity, as a README entry linking to the external repo, matching the pattern already used by other entries in that section.

It registers Claude Code's own extension bridge (`claude --claude-in-chrome-mcp`) as an MCP server, so browser tools drive the real, logged-in Chrome rather than a fresh profile. That reaches pages behind SSO or a cookie wall, which sessionless browser tools cannot without a re-login.

Repo: https://github.com/hamzahamidi/claude-in-chrome-cli (MIT, v0.2.1)

Against the checklist: it addresses a real use case (authenticated pages), does not duplicate an existing entry, and is tested. The plugin, the bundled skill, and the shell script all run against a live extension.