### PR TITLE
Add checkpoint-vivo to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [checkpoint-vivo](https://github.com/Balli-tech/checkpoint-vivo) - Session state that survives compaction. Three hooks keep a checkpoint on disk and restore it at session start, resume, and after compaction; the PreCompact hook records git log, uncommitted files, and recent requests unattended. No MCP server and no dependencies — plain hooks plus one skill.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adding [checkpoint-vivo](https://github.com/Balli-tech/checkpoint-vivo) under Developer Productivity, as an external-repo entry (same pattern as `context-mode`, `codebase-graph` and `backlog`).

**What it does**

Keeps a checkpoint on disk and restores it into context automatically:

- `SessionStart` — injects it at session start, resume, and after compaction
- `PreCompact` — records git log, uncommitted files and the most recent user requests on its own, writing only between HTML markers so hand-written text is never overwritten
- `Stop` — asks the agent to refresh the checkpoint when a commit is newer than the file
- A `checkpoint` skill teaches the agent to record decisions **and discarded alternatives** — the part that is most expensive to rediscover after compaction

**How it differs from what is already listed**

`backlog` covers cross-session task management through 24 MCP tools; `context-mode` reduces context by sandboxing large outputs. This one does neither: it has no MCP server and no dependencies, and it targets the narrower problem of *intent* surviving compaction — what was being done and what was already ruled out.

**Why the trigger is a commit, not context size:** the agent cannot read how much of the window it has consumed, since no tool returns that number. A commit is observable, so it stands in for "a block of work closed and was not recorded".

MIT, Python 3.10+, tested on Windows and POSIX shells.