### PR TITLE
docs: add CloudBase (Tencent CloudBase AI Toolkit) to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [CloudBase](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) - Tencent CloudBase plugin for Claude Code — MCP tools and agent skills for auth, database, functions, storage, and CloudRun. ([Setup](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ide-setup/claude))
 
 ### Frontend & Design
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
-- [CloudBase](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) - Tencent CloudBase plugin for Claude Code — MCP tools and agent skills for auth, database, functions, storage, and CloudRun. ([Setup](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ide-setup/claude))
+- [CloudBase](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) - Tencent CloudBase plugin for Claude Code — MCP tools and agent skills for auth, database, functions, storage, and CloudRun. ([Setup](https://docs.cloudbase.net/en/ai/cloudbase-ai-toolkit/ide-setup/claude-code))
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary
- Add CloudBase under Integrations as an external Claude Code plugin listing.
- Links to https://github.com/TencentCloudBase/CloudBase-AI-Toolkit and setup docs: https://docs.cloudbase.net/en/ai/cloudbase-ai-toolkit/ide-setup/claude-code

## About the plugin
CloudBase is Tencent Cloud BaaS. The Claude Code plugin ships MCP tools plus agent skills for auth, database, cloud functions, storage, and CloudRun.

Install:
```
claude plugin marketplace add TencentCloudBase/CloudBase-MCP
claude plugin install cloudbase@tencent-cloudbase
```

## Checklist
- [x] Real use case
- [x] No duplicate Integrations entries
- [x] Matches external plugin README format (e.g. kaggle-skill)
- [x] Plugin is public and documented