### PR TITLE
Add youtube-skills to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube for your agent. Get video transcripts, search YouTube, browse channels, and pull playlists in plain English, no Google API key or OAuth setup. Twelve skills, install with `npx skills add ZeroPointRepo/youtube-skills`.
 
 ### Frontend & Design
 


### PR DESCRIPTION
Adds **youtube-skills** to the Integrations section.

Gives an agent YouTube transcripts, video and channel search, channel browsing, playlist extraction, and new-upload tracking from plain English prompts. No Google API key and no OAuth setup, and no yt-dlp or headless browser, so it keeps working from cloud IPs where YouTube blocks those.

- Repo: https://github.com/ZeroPointRepo/youtube-skills (MIT, 527 stars)
- Install: `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full`, or drop the flag to get all twelve skills
- Agent Skills format, so it runs in Claude Code, OpenClaw, Hermes Agent, and other agent runtimes
- Free tier is 100 credits on signup, no card required

The backend is TranscriptAPI (https://transcriptapi.com), an independent service that is not affiliated with YouTube or Google. I maintain the repo.

One line added, matching the format of the existing external-repo entries in Integrations (kaggle-skill, and the same pattern used by claude-familiar and nano-banana in their sections). No other changes.
