### PR TITLE
Add orgami

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [orgami](https://github.com/achevalier-dev/orgami) - Maps every repo in a GitHub organization from committed configuration — stack, run and test commands, deploys, and repo-to-repo edges that each carry the `file:line` they came from — and hands the relevant slice to the agent at session start. Adds daily and weekly PR digests where `jq` computes the numbers, plus a shared team note store.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [orgami](https://github.com/achevalier-dev/orgami) under **Developer Productivity**.

**What it does.** It maps every repository in a GitHub organization from what is actually committed — stack, run and test commands, deploy tooling, servers, backing services and repo-to-repo references — into a graph, and hands the relevant slice to Claude Code at session start, so a session in a mapped checkout starts with the repo's context already loaded. Every edge in that graph carries the `file:line` it came from: nothing in it is inferred by a model, and a missing edge means "not found in committed configuration" rather than "not connected".

It also writes daily and weekly pull request digests where `jq` computes every number and the model is told the numbers rather than asked to count them, and keeps a shared note store so what one person learns is in everyone's session.

**Plugin structure.** `.claude-plugin/`, `commands/`, `hooks/` and `skills/orgami/SKILL.md`, installed either via the bootstrap script or by hand.

**Against the checklist:**

- *Addresses a real use case* — small teams with several repos and no maintained architecture doc, where each agent session otherwise re-derives the same facts.
- *Doesn't duplicate existing functionality* — the closest entry is `codebase-graph`, which builds a knowledge graph from source within a repository via tree-sitter and MCP. orgami works at organization scope from committed configuration and pairs the map with PR digests and team notes; the two do not overlap in what they read or produce.
- *Tested* — shellcheck and a test suite run in CI on every push, and the demo in the README is recorded against a public organization.
- MIT licensed. Bash, `gh`, `jq`, `fzf` and `gum` underneath — no daemon, no database, no hosted service.

Happy to move it to a different category or shorten the entry.