### PR TITLE
Add climits — pace governor for subscription limits (DevOps & Performance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [climits](https://github.com/likemusic/climits) - Paces subscription usage against a time line instead of just reporting it: from hooks it warns, pauses a call until the line catches up, asks once when the wait would be long, or — in a headless run — declines with a growing backoff and tells the agent to schedule a wake-up, so an overnight run pauses instead of dying. Python standard library only, enforcement off by default.
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds one line to **DevOps & Performance**, next to the other cost/usage tools. The plugin lives in its own repository, so this is a README-only change — no plugin folder copied in-tree, following the pattern of `aws-cost-saver`, `Manifest` and `kaggle-skill`.

**[climits](https://github.com/likemusic/climits)** — a pace governor for Claude Code subscription limits.

Existing tools in this space report how much quota is left, or resume a session after it runs out. climits converts the remaining quota into *how much you were allowed to have spent by this minute* and acts on the gap from hooks: it warns, pauses a call until the pace line catches up (the session never notices), asks once when the wait would be long, or — in a headless run — declines with a growing backoff and tells the agent to schedule a wake-up. It never ends the session, which is the point: an overnight autonomous run that hits a limit should pause and resume, not die.

Against your checklist:

- **Real use case** — shared team accounts especially: the counter is common, so one person's burst stops everybody. Pacing the counter keeps it alive to the end of the week.
- **No duplication** — nothing currently listed does enforcement. `Manifest` observes cost, `aws-cost-saver` optimises AWS spend; neither acts on Claude Code's own subscription windows from hooks.
- **Tested** — 94-scenario self-test (`python3 tests/selftest.py`), no network or live account required. `claude plugin validate --strict` passes.
- **Structure** — standard layout, MIT, no dependencies beyond the Python standard library, enforcement off by default so a fresh install only observes.

One thing worth stating plainly since it involves credentials: the plugin reads the OAuth token the Claude Code CLI already stores in `~/.claude/.credentials.json` and calls `GET /api/oauth/usage` — the same endpoint behind `/usage` — at most once every five minutes. It sends nothing anywhere else and has no telemetry. This is documented in a dedicated README section rather than buried.