### PR TITLE
Add attune-ai (memory + receipt-verified workflows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [attune-ai](https://github.com/Smart-AI-Memory/attune-ai) - Persistent memory and receipt-verified workflows for Claude Code. Cross-session stash → recall → promote memory loop with a git-tracked corpus, plus fixes gated by acceptance probes that re-run independently of the agent. 28 auto-triggering skills, 61 MCP tools.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [attune-ai](https://github.com/Smart-AI-Memory/attune-ai) to Developer Productivity as an external entry (same pattern as CCHub, context-mode, backlog).

- Real use case: cross-session persistent memory (stash → recall → promote, git-tracked corpus) and receipt-verified fixes — acceptance probes declared up front and re-run independently of the agent, so exit 0 reflects probe results, not self-report.
- No duplicate of an existing entry (no memory-loop + verified-receipts plugin on the list).
- Tested: shipped on PyPI (v12.0.0), 20k+ test suite, Apache-2.0; installable via `claude plugin marketplace add Smart-AI-Memory/attune-ai`.