### PR TITLE
Add SandBase Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [SandBase Skills](https://github.com/sandbaseai/sandbase-skills) - Claude Code marketplace plugin with 88 on-demand skills for evidence-led research, social intelligence, marketing, and business workflows; includes a no-account multi-source research workflow.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Add SandBase Skills to Developer Productivity as an external Claude Code marketplace plugin.

## Why it fits

- 88 installable, on-demand Skills for research, social intelligence, marketing, and business workflows
- standard Claude Code marketplace manifest at .claude-plugin/marketplace.json
- tested install flow documented in the repository
- flagship multi-source-search workflow works with Claude Code host search tools and requires no SandBase account
- Apache-2.0 licensed, versioned v0.3.4 release

## Links

- Repository: https://github.com/sandbaseai/sandbase-skills
- Release: https://github.com/sandbaseai/sandbase-skills/releases/tag/v0.3.4
- Manifest: https://github.com/sandbaseai/sandbase-skills/blob/main/.claude-plugin/marketplace.json

Disclosure: I am contributing this listing on behalf of the SandBase project.