### PR TITLE
Add claude-carbon (carbon footprint tracking for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [claude-carbon](https://github.com/gwittebolle/claude-carbon) - Carbon footprint tracking for Claude Code sessions: live CO2 in the status line, per-model reports, shareable PNG report cards. Includes `carbon-report` and `carbon-card` skills. ([Methodology](https://tokenclimate.com/methodology))
 
 ### Documentation & Security
 


### PR DESCRIPTION
Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon), an MIT-licensed tool that tracks the CO2 footprint of Claude Code sessions: live estimate in the status line, per-model session reports, and shareable PNG report cards (EN/FR). 160+ stars, actively maintained since April 2026, methodology publicly documented. I'm the author.
