### PR TITLE
Add arena under Frontend & Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [arena](https://github.com/dravensoft-dev/arena) - Token-driven design system as a skill: React and Angular component libraries on a shared Tailwind layer, with the API and the accessibility pattern of every component written as a contract the agent reads before it writes. Carries the design language and not the skin.
 
 ### Git & Version Control
 


### PR DESCRIPTION
Adding [arena](https://github.com/dravensoft-dev/arena) to **Frontend & Design**, linked to its own repository in the style of the `kaggle-skill` entry rather than vendored as a folder, since the plugin manifest and its version live there and a copy here would fork the source of truth.

**What it does.** Arena is a design system published twice, as `@dravensoft/arena-react` and `@dravensoft/arena-angular` over one shared Tailwind layer, and shipped as a Claude Code plugin so an agent can build screens with it. Install:

```
/plugin marketplace add dravensoft-dev/arena
/plugin install arena@dravensoft
```

**Why it is worth a row.** The skill does not describe the components in prose. Every component's API and the accessibility pattern it binds are contract files, and a gate in the repository fails when the code, the documentation or the published package stops answering them, so what the agent reads is checked rather than asserted. It ships no palette and no fonts either: a project declares those in its own `arena.config.json`.

MIT. `claude plugin validate` passes. Live components at https://arena.dravensoft.org and the agent corpus at https://arena.dravensoft.org/llms.txt