### PR TITLE
feat: add You.com search integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [you-search](https://github.com/youdotcom-oss/agent-skills) - Real-time web search, URL content extraction, and AI-powered research via You.com MCP server. Provides current web information, cited sources, and content analysis for coding projects.
 
 ### Frontend & Design
 


### PR DESCRIPTION
## Summary

Add You.com search integration to the plugin marketplace's Integrations section.

## What this adds

This PR adds You.com as a curated plugin option, providing Claude Code users with:
- **Real-time web search** - Current information from across the web
- **URL content extraction** - Read and analyze web pages directly  
- **AI-powered research synthesis** - Cited, structured research reports
- **Source verification** - Factual claims backed by URLs

## Why this fits the marketplace

**Distribution surface match**: You.com already provides a complete Claude Code plugin via the [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) repository with proper Claude Code plugin manifests and MCP server configurations.

**Installation flow**: Users can install with standard Claude Code commands:
```bash
git clone https://github.com/youdotcom-oss/agent-skills.git
claude --plugin-dir ./agent-skills
```

**Marketplace precedent**: Follows the same pattern as other external integrations like `kaggle-skill` - pointing to an external repository rather than bundling plugin code directly.

## Implementation

- Added entry to Integrations section following established format
- Links to existing `youdotcom-oss/agent-skills` repository  
- No code changes required - pure marketplace listing
- Maintains all existing functionality

## Testing

- Verified link accessibility and repository structure
- Confirmed agent-skills repo contains proper Claude Code plugin manifests
- Tested description formatting consistency with existing entries

The You.com integration leverages MCP (Model Context Protocol) servers for clean, standards-based integration with Claude Code and provides optional authenticated access via `YDC_API_KEY` or keyless operation for basic usage.