### PR TITLE
docs(readme): add backlog-skill to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [backlog-skill](https://github.com/SI-IC/backlog-skill) - Deferred tasks as plain files in your repo — one markdown file per task in `docs/backlogs/`, under version control, reviewable in a PR diff. Claude offers to record an out-of-scope finding and writes only after you say yes; three and only three cases where an entry is written. Python stdlib only — no MCP server, no database, no daemon.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [backlog-skill](https://github.com/SI-IC/backlog-skill) to **Developer Productivity** — one line, external link, no vendored copy.

**What it is:** deferred tasks for Claude Code as plain files in your repo. One markdown file per task in `docs/backlogs/`, under version control, reviewable in a PR diff.

**Why it isn't a duplicate of the existing `backlog` entry** (`backloghq/backlog`): that one is an MCP server with 24 tools and event-sourced storage. This one has no MCP server, no database and no daemon — the engine is a single stdlib-only Python script, and the entry format is plain markdown you can edit by hand. The design goal is different too: it never records on its own initiative. There are exactly three cases where an entry is written — the user asks, the user says yes to an offer to defer an out-of-scope finding, or a background session needs a decision with nobody to ask.

Checks against your CONTRIBUTING requirements:

- **Addresses a real use case** — deferred work Claude notices mid-task currently ends up in the chat and is gone next session.
- **Doesn't duplicate existing functionality** — see above; different architecture and a deliberately narrower contract.
- **Tested** — 151 tests on the engine; `claude plugin validate` passes on both the plugin and marketplace manifests, including `--strict`.
- **Maintained** — MIT, automated releases, currently v0.8.1.